### PR TITLE
Per-agent tool selection

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -109,6 +109,11 @@ Last updated: 2026-08-10
 - `Norns.Agents.SubagentPolicy` — per-agent authorization for `launch_agent` / `list_agents`, with audit events. Defaults open; existing agents unaffected.
 - Phase 1 of `plan-subagent-allowlists.md`; phases 2–3 remain proposed.
 
+### Per-agent tool selection
+- `Norns.Agents.ToolPolicy` — per-agent allowlist of worker-provided tools, parsed from `model_config["tools"]` (same shape and defaults philosophy as `SubagentPolicy`). Defaults open; existing agents unaffected.
+- Enforced twice: the allowlist filters the tool list advertised to the LLM, and dispatch rejects a call outside it (error result back to the model, `tool_call_denied` audit event). Built-ins are exempt — `launch_agent`/`list_agents` are governed by `SubagentPolicy`.
+- The compose-mode prerequisite from `plan-agent-builder.md`: agents can now be assembled from a subset of the tenant's capability layer.
+
 ### Sub-agent crash recovery
 - A resumed parent reattaches to its in-flight child by run id instead of relaunching it — a pending `launch_agent` is a reference to work already underway, not a request.
 - Subscribe-before-read closes the completion race; `run_id` rides on every agent broadcast; a parent resumed alone restarts its own orphaned child.
@@ -125,10 +130,7 @@ Last updated: 2026-08-10
 ### Policy enforcement
 - Pre-dispatch hook point in the orchestrator (not built, architecture supports it).
 - Rule-based (orchestrator evaluates) and LLM-evaluated (worker evaluates) flavors.
-- `SubagentPolicy` and the planned per-agent tool selection are both bespoke policy checks; a third one is the signal to build the generic hook.
-
-### Per-agent tool selection
-- Every agent currently sees every tool in the tenant (`process.ex` builds the LLM tool list unfiltered). Decided: add a tool allowlist to `AgentDef`, same shape as `SubagentPolicy`. Not built. First step in `roadmap.md`.
+- `SubagentPolicy` and `ToolPolicy` are both bespoke policy checks; a third one is the signal to build the generic hook.
 
 ### Cloud readiness
 Gaps that become real the moment there is a hosted product (see `roadmap.md` § Cloud readiness):

--- a/docs/plan-agent-builder.md
+++ b/docs/plan-agent-builder.md
@@ -1,7 +1,7 @@
 # Plan: Agent Builder
 
 **Status:** Direction agreed (2026-08-08); cloud boundary decided (2026-08-10) — builder ships as a Norns Cloud product, sequencing in `roadmap.md`
-**Depends on:** per-agent tool selection (not built), cron triggers (not built), gards Phase 1 (`gards.md`)
+**Depends on:** per-agent tool selection (shipped 2026-08-10), cron triggers (not built), gards Phase 1 (`gards.md`)
 
 The product direction: a builder that turns "create a Slack bot that posts the
 current call count to #general every Friday" into a running, durable agent.
@@ -47,19 +47,20 @@ agent is compose — the builder ships it without deploying anything.
 
 ## What compose mode requires
 
-### 1. Per-agent tool selection (the one core gap)
+### 1. Per-agent tool selection (the one core gap) — shipped 2026-08-10
 
-Today every agent sees every tool in the tenant: `process.ex` builds the LLM
-tool list as builtins + def tools + **all** worker tools, unfiltered
-(`process.ex:233`). "Assemble existing tools differently" is impossible when
-every agent gets the same assembly — and it's a safety problem independent of
-the builder (the call-count bot is also offered `send_email` and
-`delete_record`).
+Previously every agent saw every tool in the tenant: the LLM tool list was
+builtins + def tools + **all** worker tools, unfiltered. "Assemble existing
+tools differently" is impossible when every agent gets the same assembly —
+and it's a safety problem independent of the builder (the call-count bot is
+also offered `send_email` and `delete_record`).
 
-Fix: a tool allowlist on the AgentDef that filters `available_tools`. Same
-shape as `SubagentPolicy` (default `open` for backwards compatibility,
-explicit selection opts in), motivated by the same incident class. This is the
-prerequisite for everything else in compose mode.
+Shipped as `Norns.Agents.ToolPolicy`: a tool allowlist in
+`model_config["tools"]`, same shape as `SubagentPolicy` (default `open` for
+backwards compatibility, explicit selection opts in), motivated by the same
+incident class. It filters the advertised tool list and rejects
+out-of-policy calls at dispatch with a `tool_call_denied` audit event. This
+was the prerequisite for everything else in compose mode.
 
 ### 2. Cron triggers, as first-class Norns data
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,7 +53,7 @@ builder later composes against.
 
 ```mermaid
 flowchart TB
-    A["1 — Per-agent tool selection<br/>allowlist on AgentDef, filters available_tools"]
+    A["1 — Per-agent tool selection ✓<br/>ToolPolicy on AgentDef — shipped 2026-08-10"]
     B["2 — Cron triggers<br/>triggers table · Oban · API + nornsctl"]
     C["3 — Gards Phase 1<br/>registry + dispatch filter (+ secrets requirement)"]
     D["4 — Fabricate toolkit<br/>templates · scaffold AGENTS.md · nornsctl --wait"]
@@ -62,13 +62,13 @@ flowchart TB
     A --> B --> C --> D --> E --> F
 ```
 
-### 1. Per-agent tool selection
+### 1. Per-agent tool selection — done (2026-08-10)
 
-Today every agent sees every tool in the tenant (`process.ex:233` — builtins +
-def tools + all worker tools, unfiltered). Composing agents from a shared
-capability layer is impossible without scoping, and it's a safety gap
-regardless. Add a tool allowlist to `AgentDef`, same shape and defaults
-philosophy as `SubagentPolicy`. Small, prerequisite for everything below.
+Shipped as `Norns.Agents.ToolPolicy`: a per-agent allowlist of worker tools
+in `model_config["tools"]`, same shape and defaults philosophy as
+`SubagentPolicy`. Filters the advertised tool list and rejects out-of-policy
+calls at dispatch with a `tool_call_denied` audit event; built-ins exempt.
+See `decision-log.md` § Implemented.
 
 ### 2. Cron triggers
 

--- a/lib/norns/agents/agent_def.ex
+++ b/lib/norns/agents/agent_def.ex
@@ -14,7 +14,8 @@ defmodule Norns.Agents.AgentDef do
     checkpoint_policy: :on_tool_call,
     max_steps: 50,
     on_failure: :stop,
-    subagents: %Norns.Agents.SubagentPolicy{}
+    subagents: %Norns.Agents.SubagentPolicy{},
+    tool_policy: %Norns.Agents.ToolPolicy{}
   ]
 
   @type context_strategy :: :sliding_window | :none
@@ -30,7 +31,8 @@ defmodule Norns.Agents.AgentDef do
           checkpoint_policy: checkpoint_policy(),
           max_steps: pos_integer(),
           on_failure: failure_policy(),
-          subagents: Norns.Agents.SubagentPolicy.t()
+          subagents: Norns.Agents.SubagentPolicy.t(),
+          tool_policy: Norns.Agents.ToolPolicy.t()
         }
 
   @current_version 1
@@ -87,7 +89,8 @@ defmodule Norns.Agents.AgentDef do
       max_steps: agent.max_steps || 50,
       checkpoint_policy: parse_checkpoint_policy(config),
       on_failure: parse_failure_policy(config),
-      subagents: Norns.Agents.SubagentPolicy.from_config(config)
+      subagents: Norns.Agents.SubagentPolicy.from_config(config),
+      tool_policy: Norns.Agents.ToolPolicy.from_config(config)
     }
   end
 

--- a/lib/norns/agents/process.ex
+++ b/lib/norns/agents/process.ex
@@ -9,7 +9,7 @@ defmodule Norns.Agents.Process do
   require Logger
 
   alias Norns.{Agents, Conversations, Runs, Tenants}
-  alias Norns.Agents.{AgentDef, SubagentPolicy}
+  alias Norns.Agents.{AgentDef, SubagentPolicy, ToolPolicy}
   alias Norns.Runtime.{ErrorPolicy, Errors, Events}
   alias Norns.Workers.WorkerRegistry
   alias Norns.Tools.{Builtins, Idempotency, Tool}
@@ -227,10 +227,13 @@ defmodule Norns.Agents.Process do
     else
       state = %{state | step: state.step + 1}
 
-      # Resolve tools at dispatch time: built-ins + agent_def tools + worker-registered tools
+      # Resolve tools at dispatch time: built-ins + agent_def tools + worker-registered
+      # tools, the latter two filtered by the agent's tool policy. Built-ins are
+      # orchestrator semantics — launch_agent/list_agents have their own policy.
+      policy = state.agent_def.tool_policy
       builtin_tools = Builtins.all()
-      agent_tools = state.agent_def.tools
-      worker_tools = WorkerRegistry.available_tools(state.tenant_id)
+      agent_tools = ToolPolicy.filter(policy, state.agent_def.tools)
+      worker_tools = ToolPolicy.filter(policy, WorkerRegistry.available_tools(state.tenant_id))
       all_tools = (builtin_tools ++ agent_tools ++ worker_tools) |> Enum.uniq_by(& &1.name)
       tools = Enum.map(all_tools, &Tool.to_api_format/1)
 
@@ -324,6 +327,16 @@ defmodule Norns.Agents.Process do
     {launch_agent_blocks, regular_blocks} =
       Enum.split_with(remaining, fn block -> block["name"] == "launch_agent" end)
 
+    # Enforce the tool policy at dispatch, not just at advertisement — the
+    # model can name a tool it was never offered, or the allowlist can have
+    # changed mid-conversation. Built-ins were already split out above.
+    {denied_blocks, regular_blocks} =
+      Enum.split_with(regular_blocks, fn block ->
+        ToolPolicy.authorize(state.agent_def.tool_policy, block["name"]) != :ok
+      end)
+
+    denied_results = resolve_denied_tools(state, denied_blocks, log_calls?)
+
     # Resolve list_agents synchronously — results go into the pool immediately
     list_agents_results = resolve_list_agents(state, list_agents_blocks, log_calls?)
 
@@ -331,7 +344,7 @@ defmodule Norns.Agents.Process do
     {launch_results, launch_pending, state} =
       resolve_launch_agents(state, launch_agent_blocks, log_calls?)
 
-    sync_results = list_agents_results ++ launch_results
+    sync_results = denied_results ++ list_agents_results ++ launch_results
 
     # Log tool_call events for regular (worker-dispatched) blocks
     if log_calls? do
@@ -393,6 +406,40 @@ defmodule Norns.Agents.Process do
     else
       handle_pause_or_continue(state, wait_blocks, ask_blocks, sync_results, log_calls?)
     end
+  end
+
+  # A denied tool call gets an error result back to the LLM (recoverable — it
+  # can pick an allowed tool) and a tool_call_denied audit event, mirroring
+  # the subagent decision trail.
+  defp resolve_denied_tools(state, blocks, log_calls?) do
+    Enum.map(blocks, fn block ->
+      if log_calls? do
+        append(state.run, Events.tool_call(%{
+          "tool_call_id" => block["id"],
+          "name" => block["name"],
+          "arguments" => block["arguments"] || %{},
+          "step" => state.step
+        }))
+      end
+
+      policy = state.agent_def.tool_policy
+
+      append(state.run, Events.build("tool_call_denied", %{
+        "requesting_agent_id" => state.agent_id,
+        "requesting_agent_name" => (state.agent && state.agent.name) || "",
+        "mode" => to_string(policy.mode),
+        "tool_name" => block["name"],
+        "reason" => "not_allowlisted",
+        "step" => state.step
+      }))
+
+      make_error_tool_result(
+        state,
+        block,
+        block["name"],
+        "Tool '#{block["name"]}' is not in this agent's allowed tools."
+      )
+    end)
   end
 
   defp resolve_list_agents(state, blocks, log_calls?) do

--- a/lib/norns/agents/tool_policy.ex
+++ b/lib/norns/agents/tool_policy.ex
@@ -1,0 +1,93 @@
+defmodule Norns.Agents.ToolPolicy do
+  @moduledoc """
+  Per-agent selection of worker-provided tools.
+
+  Parsed from an agent's `model_config` under the `"tools"` key:
+
+      {
+        "tools": {
+          "mode": "allowlist",
+          "allowed_tools": ["post_to_slack", "get_call_count"]
+        }
+      }
+
+  Modes:
+
+    * `:open` — the agent is offered every tool registered in the tenant (the
+      default, and the behaviour before this policy existed)
+    * `:allowlist` — the agent is offered only the tools named in
+      `allowed_tools`
+
+  The policy governs worker-provided tools only. Built-ins (`wait`,
+  `ask_human`, `launch_agent`, `list_agents`) are orchestrator semantics and
+  are never filtered here — `launch_agent` and `list_agents` have their own
+  policy in `Norns.Agents.SubagentPolicy`.
+
+  The policy is enforced twice: the allowlist filters which tools are
+  advertised to the LLM, and dispatch rejects a call to a tool outside it —
+  a model can name a tool it was never offered, or the allowlist can change
+  mid-conversation. Denials are audited as `tool_call_denied` events; allowed
+  calls are not, since `llm_request` already records the offered tool names
+  and tool calls are the hot path.
+
+  Defaults are deliberately permissive so that adding the policy doesn't
+  change behaviour for agents that don't configure it.
+  """
+
+  defstruct mode: :open, allowed_tools: []
+
+  @type mode :: :open | :allowlist
+
+  @type t :: %__MODULE__{
+          mode: mode(),
+          allowed_tools: [String.t()]
+        }
+
+  @doc "Parse a policy out of an agent's `model_config`. Unknown values fall back to the permissive default."
+  @spec from_config(map() | nil) :: t()
+  def from_config(config) when is_map(config) do
+    case Map.get(config, "tools") do
+      settings when is_map(settings) ->
+        %__MODULE__{
+          mode: parse_mode(Map.get(settings, "mode")),
+          allowed_tools: parse_allowed(Map.get(settings, "allowed_tools"))
+        }
+
+      _ ->
+        %__MODULE__{}
+    end
+  end
+
+  def from_config(_), do: %__MODULE__{}
+
+  @doc """
+  Whether this agent may call `tool_name`.
+
+  Returns `:ok`, or `{:error, "not_allowlisted"}` — a stable code suitable
+  for the audit event.
+  """
+  @spec authorize(t(), String.t()) :: :ok | {:error, String.t()}
+  def authorize(%__MODULE__{mode: :open}, _tool_name), do: :ok
+
+  def authorize(%__MODULE__{mode: :allowlist, allowed_tools: allowed}, tool_name) do
+    if tool_name in allowed, do: :ok, else: {:error, "not_allowlisted"}
+  end
+
+  @doc "Filter a tool list down to those the policy allows. Accepts `Norns.Tools.Tool` structs or map-shaped tool defs."
+  @spec filter(t(), [Norns.Tools.Tool.t() | map()]) :: [Norns.Tools.Tool.t() | map()]
+  def filter(%__MODULE__{mode: :open}, tools), do: tools
+
+  def filter(%__MODULE__{} = policy, tools) do
+    Enum.filter(tools, fn tool -> authorize(policy, tool_name(tool)) == :ok end)
+  end
+
+  defp tool_name(%{name: name}), do: name
+  defp tool_name(%{"name" => name}), do: name
+  defp tool_name(_), do: nil
+
+  defp parse_mode("allowlist"), do: :allowlist
+  defp parse_mode(_), do: :open
+
+  defp parse_allowed(names) when is_list(names), do: Enum.filter(names, &is_binary/1)
+  defp parse_allowed(_), do: []
+end

--- a/lib/norns/runtime/event_validator.ex
+++ b/lib/norns/runtime/event_validator.ex
@@ -79,6 +79,9 @@ defmodule Norns.Runtime.EventValidator do
       decision when decision in ["subagent_launch_allowed", "subagent_launch_denied", "subagent_list_allowed", "subagent_list_denied"] ->
         [schema_version_validator(), required_integer("requesting_agent_id"), required_string("mode"), required_integer("step")]
 
+      "tool_call_denied" ->
+        [schema_version_validator(), required_integer("requesting_agent_id"), required_string("mode"), required_string("tool_name"), required_string("reason"), required_integer("step")]
+
       "waiting_for_timer" -> [schema_version_validator(), required_string("tool_call_id"), required_integer("seconds"), required_integer("step")]
       "waiting_for_user" -> [schema_version_validator(), required_string("question"), required_string("tool_call_id"), required_integer("step")]
       "user_response" -> [schema_version_validator(), required_string("content"), required_string("tool_call_id"), required_integer("step")]

--- a/test/norns/agents/process_tool_policy_test.exs
+++ b/test/norns/agents/process_tool_policy_test.exs
@@ -1,0 +1,191 @@
+defmodule Norns.Agents.ProcessToolPolicyTest do
+  use Norns.DataCase, async: false
+
+  alias Norns.Runs
+  alias Norns.Agents.Process, as: AgentProcess
+  alias Norns.LLM.Fake
+  alias Norns.Tools.Tool
+
+  setup do
+    tenant = create_tenant()
+    %{tenant: tenant}
+  end
+
+  defp tool(name) do
+    %Tool{
+      name: name,
+      description: "test tool #{name}",
+      input_schema: %{},
+      handler: fn _ -> {:ok, "result from #{name}"} end
+    }
+  end
+
+  defp allowlist_agent(tenant, allowed) do
+    create_agent(tenant, %{
+      model_config: %{"tools" => %{"mode" => "allowlist", "allowed_tools" => allowed}}
+    })
+  end
+
+  defp subscribe_and_send(pid, agent_id, content) do
+    Phoenix.PubSub.subscribe(Norns.PubSub, "agent:#{agent_id}")
+    AgentProcess.send_message(pid, content)
+  end
+
+  defp wait_for(event, timeout \\ 5000) do
+    receive do
+      {^event, payload} -> payload
+    after
+      timeout -> flunk("Did not receive #{event} within #{timeout}ms")
+    end
+  end
+
+  describe "tool advertisement" do
+    test "allowlist filters offered tools; built-ins are exempt", %{tenant: tenant} do
+      agent = allowlist_agent(tenant, ["allowed_tool"])
+
+      Fake.set_responses([
+        %{content: [%{"type" => "text", "text" => "done"}], stop_reason: "end_turn"}
+      ])
+
+      {:ok, pid} =
+        AgentProcess.start_link(
+          agent_id: agent.id,
+          tenant_id: tenant.id,
+          tools: [tool("allowed_tool"), tool("forbidden_tool")]
+        )
+
+      subscribe_and_send(pid, agent.id, "hello")
+      wait_for(:completed)
+
+      run = Runs.get_run!(AgentProcess.get_state(pid).run_id)
+      request = Enum.find(Runs.list_events(run.id), &(&1.event_type == "llm_request"))
+      offered = request.payload["tools"]
+
+      assert "allowed_tool" in offered
+      refute "forbidden_tool" in offered
+
+      for builtin <- ["wait", "ask_human", "launch_agent", "list_agents"] do
+        assert builtin in offered
+      end
+    end
+
+    test "the default (no policy configured) offers everything", %{tenant: tenant} do
+      agent = create_agent(tenant)
+
+      Fake.set_responses([
+        %{content: [%{"type" => "text", "text" => "done"}], stop_reason: "end_turn"}
+      ])
+
+      {:ok, pid} =
+        AgentProcess.start_link(
+          agent_id: agent.id,
+          tenant_id: tenant.id,
+          tools: [tool("allowed_tool"), tool("forbidden_tool")]
+        )
+
+      subscribe_and_send(pid, agent.id, "hello")
+      wait_for(:completed)
+
+      run = Runs.get_run!(AgentProcess.get_state(pid).run_id)
+      request = Enum.find(Runs.list_events(run.id), &(&1.event_type == "llm_request"))
+
+      assert "allowed_tool" in request.payload["tools"]
+      assert "forbidden_tool" in request.payload["tools"]
+    end
+  end
+
+  describe "dispatch enforcement" do
+    test "a call to a tool outside the allowlist is denied with an audit event", %{tenant: tenant} do
+      agent = allowlist_agent(tenant, ["allowed_tool"])
+
+      Fake.set_responses([
+        %{
+          content: [
+            %{"type" => "tool_use", "id" => "call_1", "name" => "web_search", "input" => %{"query" => "x"}}
+          ],
+          stop_reason: "tool_use"
+        },
+        %{content: [%{"type" => "text", "text" => "understood"}], stop_reason: "end_turn"}
+      ])
+
+      {:ok, pid} = AgentProcess.start_link(agent_id: agent.id, tenant_id: tenant.id)
+      subscribe_and_send(pid, agent.id, "search for x")
+      wait_for(:completed)
+
+      run = Runs.get_run!(AgentProcess.get_state(pid).run_id)
+      events = Runs.list_events(run.id)
+      assert run.status == "completed"
+
+      denial = Enum.find(events, &(&1.event_type == "tool_call_denied"))
+      assert denial.payload["tool_name"] == "web_search"
+      assert denial.payload["reason"] == "not_allowlisted"
+      assert denial.payload["mode"] == "allowlist"
+      assert denial.payload["requesting_agent_id"] == agent.id
+
+      result =
+        Enum.find(events, fn e ->
+          e.event_type == "tool_result" and e.payload["tool_call_id"] == "call_1"
+        end)
+
+      assert result.payload["is_error"] == true
+      assert result.payload["content"] =~ "not in this agent's allowed tools"
+
+      # The denial fed back to the LLM, which ran again and finished.
+      assert Enum.count(events, &(&1.event_type == "llm_request")) == 2
+    end
+
+    test "built-ins still work under an empty allowlist", %{tenant: tenant} do
+      agent = allowlist_agent(tenant, [])
+
+      Fake.set_responses([
+        %{
+          content: [
+            %{"type" => "tool_use", "id" => "call_ask", "name" => "ask_human", "input" => %{"question" => "Which channel?"}}
+          ],
+          stop_reason: "tool_use"
+        }
+      ])
+
+      {:ok, pid} = AgentProcess.start_link(agent_id: agent.id, tenant_id: tenant.id)
+      subscribe_and_send(pid, agent.id, "post the report")
+
+      payload = wait_for(:waiting_for_user)
+      assert payload.question == "Which channel?"
+
+      run = Runs.get_run!(AgentProcess.get_state(pid).run_id)
+      refute Enum.any?(Runs.list_events(run.id), &(&1.event_type == "tool_call_denied"))
+    end
+
+    test "an allowed tool call dispatches normally under an allowlist", %{tenant: tenant} do
+      agent = allowlist_agent(tenant, ["web_search"])
+
+      Fake.set_responses([
+        %{
+          content: [
+            %{"type" => "tool_use", "id" => "call_1", "name" => "web_search", "input" => %{"query" => "elixir"}}
+          ],
+          stop_reason: "tool_use"
+        },
+        %{content: [%{"type" => "text", "text" => "found it"}], stop_reason: "end_turn"}
+      ])
+
+      {:ok, pid} = AgentProcess.start_link(agent_id: agent.id, tenant_id: tenant.id)
+      subscribe_and_send(pid, agent.id, "search for elixir")
+      wait_for(:completed)
+
+      run = Runs.get_run!(AgentProcess.get_state(pid).run_id)
+      events = Runs.list_events(run.id)
+      assert run.status == "completed"
+
+      refute Enum.any?(events, &(&1.event_type == "tool_call_denied"))
+
+      result =
+        Enum.find(events, fn e ->
+          e.event_type == "tool_result" and e.payload["tool_call_id"] == "call_1"
+        end)
+
+      assert result.payload["is_error"] == false
+      assert result.payload["content"] =~ "Search results"
+    end
+  end
+end

--- a/test/norns/agents/tool_policy_test.exs
+++ b/test/norns/agents/tool_policy_test.exs
@@ -1,0 +1,78 @@
+defmodule Norns.Agents.ToolPolicyTest do
+  use ExUnit.Case, async: true
+
+  alias Norns.Agents.ToolPolicy
+  alias Norns.Tools.Tool
+
+  describe "from_config/1" do
+    test "defaults to open" do
+      policy = ToolPolicy.from_config(%{})
+
+      assert policy.mode == :open
+      assert policy.allowed_tools == []
+    end
+
+    test "reads an allowlist when configured" do
+      policy =
+        ToolPolicy.from_config(%{
+          "tools" => %{"mode" => "allowlist", "allowed_tools" => ["post_to_slack"]}
+        })
+
+      assert policy.mode == :allowlist
+      assert policy.allowed_tools == ["post_to_slack"]
+    end
+
+    test "junk config falls back to the permissive default" do
+      for junk <- [nil, "allowlist", 42, ["post_to_slack"]] do
+        policy = ToolPolicy.from_config(%{"tools" => junk})
+        assert policy.mode == :open
+      end
+
+      policy = ToolPolicy.from_config(%{"tools" => %{"mode" => "nonsense"}})
+      assert policy.mode == :open
+    end
+
+    test "non-string entries are dropped from the allowlist" do
+      policy =
+        ToolPolicy.from_config(%{
+          "tools" => %{"mode" => "allowlist", "allowed_tools" => ["ok", 7, nil, %{}]}
+        })
+
+      assert policy.allowed_tools == ["ok"]
+    end
+  end
+
+  describe "authorize/2" do
+    test "open mode allows anything" do
+      assert ToolPolicy.authorize(%ToolPolicy{}, "anything") == :ok
+    end
+
+    test "allowlist mode allows only named tools" do
+      policy = %ToolPolicy{mode: :allowlist, allowed_tools: ["post_to_slack"]}
+
+      assert ToolPolicy.authorize(policy, "post_to_slack") == :ok
+      assert ToolPolicy.authorize(policy, "delete_record") == {:error, "not_allowlisted"}
+    end
+
+    test "an empty allowlist denies every worker tool" do
+      policy = %ToolPolicy{mode: :allowlist, allowed_tools: []}
+      assert ToolPolicy.authorize(policy, "anything") == {:error, "not_allowlisted"}
+    end
+  end
+
+  describe "filter/2" do
+    defp tool(name), do: %Tool{name: name, description: "", input_schema: %{}, handler: fn _ -> {:ok, ""} end}
+
+    test "open mode passes the list through untouched" do
+      tools = [tool("a"), tool("b")]
+      assert ToolPolicy.filter(%ToolPolicy{}, tools) == tools
+    end
+
+    test "allowlist mode keeps only allowed tools, for structs and map defs alike" do
+      policy = %ToolPolicy{mode: :allowlist, allowed_tools: ["a"]}
+      tools = [tool("a"), tool("b"), %{"name" => "a"}, %{"name" => "c"}]
+
+      assert ToolPolicy.filter(policy, tools) == [tool("a"), %{"name" => "a"}]
+    end
+  end
+end


### PR DESCRIPTION
Adds `Norns.Agents.ToolPolicy` — a per-agent allowlist of worker-provided tools, the first step of the roadmap and the compose-mode prerequisite from `docs/plan-agent-builder.md`.

## What

- New `ToolPolicy` (mode `open` | `allowlist`), parsed from `model_config["tools"]` — same shape and defaults philosophy as `SubagentPolicy`. Defaults open, so existing agents are unaffected.
- `AgentDef` gains a `tool_policy` field, built in `from_agent/2`.
- Enforced twice in the agent process:
  - **Advertisement**: the allowlist filters def tools and worker tools before the LLM sees them. Built-ins are exempt (`launch_agent`/`list_agents` have `SubagentPolicy`).
  - **Dispatch**: a call to a tool outside the allowlist gets an error result back to the model and a `tool_call_denied` audit event, mirroring the subagent decision trail. Denials only — `llm_request` already records offered tool names, so per-call "allowed" events would just be noise.
- `tool_call_denied` registered in the event validator.

## Tests

14 new tests (unit + process-level): config parsing incl. junk fallback, advertisement filtering, dispatch denial with audit event and recovery, built-ins under an empty allowlist, allowed calls dispatching normally. Full suite: 224 tests, 0 failures, `--warnings-as-errors` clean, credo clean.

Docs updated: decision log (moved to Implemented), roadmap step 1 marked done, agent-builder plan updated.