### PR TITLE
Cron triggers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ lib/norns/
   conversations/    — Conversation schema + context (persistent chat history)
   runs/             — Run + RunEvent schemas, Runs context (event log)
   runtime/          — Event contracts, error taxonomy, retry policy
-  workers/          — WorkerRegistry, TaskQueue, ResumeAgents
+  triggers/         — Trigger schema + context (cron schedules that start runs)
+  workers/          — WorkerRegistry, TaskQueue, ResumeAgents, TriggerScheduler
   llm.ex            — LLM dispatcher (used by workers via Fake in tests)
   llm/              — Behaviour, Anthropic adapter, Format (neutral ↔ Anthropic), Fake
   tools/            — Behaviour, Tool struct, Executor, Registry, Idempotency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ lib/norns/
   conversations/    — Conversation schema + context (persistent chat history)
   runs/             — Run + RunEvent schemas, Runs context (event log)
   runtime/          — Event contracts, error taxonomy, retry policy
-  workers/          — WorkerRegistry, TaskQueue, ResumeAgents
+  triggers/         — Trigger schema + context (cron schedules that start runs)
+  workers/          — WorkerRegistry, TaskQueue, ResumeAgents, TriggerScheduler
   llm.ex            — LLM dispatcher (used by workers via Fake in tests)
   llm/              — Behaviour, Anthropic adapter, Format (neutral ↔ Anthropic), Fake
   tools/            — Behaviour, Tool struct, Executor, Registry, Idempotency

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,8 @@ config :norns, Norns.Repo,
 config :norns, Oban,
   repo: Norns.Repo,
   plugins: [
-    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7}
+    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
+    {Oban.Plugins.Cron, crontab: [{"* * * * *", Norns.Workers.TriggerScheduler}]}
   ],
   queues: [default: 10]
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -114,6 +114,12 @@ Last updated: 2026-08-10
 - Enforced twice: the allowlist filters the tool list advertised to the LLM, and dispatch rejects a call outside it (error result back to the model, `tool_call_denied` audit event). Built-ins are exempt — `launch_agent`/`list_agents` are governed by `SubagentPolicy`.
 - The compose-mode prerequisite from `plan-agent-builder.md`: agents can now be assembled from a subset of the tenant's capability layer.
 
+### Cron triggers
+- `Norns.Triggers` — `triggers` table (agent, cron, message, optional persistent `conversation_key`), full CRUD at `/api/v1/triggers`, plus `POST /triggers/:id/fire` to test outside the schedule (doesn't consume the scheduled minute).
+- Fired by a minutely Oban job (`TriggerScheduler` via the Cron plugin). Dedupe is an atomic `last_fired_at` claim: at most one firing per trigger per matching minute, however many schedulers observe it.
+- Runs started by a trigger carry `trigger_type: "schedule"`. Cron expressions validated with `Oban.Cron.Expression` at write time.
+- Default is task mode (fresh conversation per firing); setting `conversation_key` opts into shared history across firings.
+
 ### Sub-agent crash recovery
 - A resumed parent reattaches to its in-flight child by run id instead of relaunching it — a pending `launch_agent` is a reference to work already underway, not a request.
 - Subscribe-before-read closes the completion race; `run_id` rides on every agent broadcast; a parent resumed alone restarts its own orphaned child.

--- a/docs/plan-agent-builder.md
+++ b/docs/plan-agent-builder.md
@@ -1,7 +1,7 @@
 # Plan: Agent Builder
 
 **Status:** Direction agreed (2026-08-08); cloud boundary decided (2026-08-10) — builder ships as a Norns Cloud product, sequencing in `roadmap.md`
-**Depends on:** per-agent tool selection (shipped 2026-08-10), cron triggers (not built), gards Phase 1 (`gards.md`)
+**Depends on:** per-agent tool selection (shipped 2026-08-10), cron triggers (shipped 2026-08-10), gards Phase 1 (`gards.md`)
 
 The product direction: a builder that turns "create a Slack bot that posts the
 current call count to #general every Friday" into a running, durable agent.
@@ -62,16 +62,19 @@ incident class. It filters the advertised tool list and rejects
 out-of-policy calls at dispatch with a `tool_call_denied` audit event. This
 was the prerequisite for everything else in compose mode.
 
-### 2. Cron triggers, as first-class Norns data
+### 2. Cron triggers, as first-class Norns data — shipped 2026-08-10
 
 A composed agent has no repo, so trigger config cannot live in one. Triggers
-are Norns data: a `triggers` table (agent_id, cron expression, message
-template), fired by Oban (already a dependency), managed via API and
-`nornsctl`. The SDK may later grow `Agent(triggers: [...])` as sync sugar, but
-**Norns is the system of record**.
+are Norns data: a `triggers` table (agent_id, cron expression, message,
+optional persistent conversation key), fired by a minutely Oban job with an
+atomic per-minute claim, managed via `/api/v1/triggers` (including
+`POST /triggers/:id/fire` for testing outside the schedule). The SDK may
+later grow `Agent(triggers: [...])` as sync sugar, but **Norns is the system
+of record**.
 
-This also puts `trigger_type` to work: `"message"` / `"schedule"` /
-`"webhook"` on runs, improving filtering and debugging for free.
+This also put `trigger_type` to work: runs started by a trigger carry
+`"schedule"`, improving filtering and debugging for free. `"webhook"`
+arrives with inbound webhooks.
 
 ### 3. Inbound webhooks (Layer 2 of the trigger surface)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,7 +54,7 @@ builder later composes against.
 ```mermaid
 flowchart TB
     A["1 — Per-agent tool selection ✓<br/>ToolPolicy on AgentDef — shipped 2026-08-10"]
-    B["2 — Cron triggers<br/>triggers table · Oban · API + nornsctl"]
+    B["2 — Cron triggers ✓<br/>triggers table · Oban · API — shipped 2026-08-10"]
     C["3 — Gards Phase 1<br/>registry + dispatch filter (+ secrets requirement)"]
     D["4 — Fabricate toolkit<br/>templates · scaffold AGENTS.md · nornsctl --wait"]
     E["5 — Inbound webhooks<br/>POST /api/v1/hooks/:token · signature verification"]
@@ -70,12 +70,15 @@ in `model_config["tools"]`, same shape and defaults philosophy as
 calls at dispatch with a `tool_call_denied` audit event; built-ins exempt.
 See `decision-log.md` § Implemented.
 
-### 2. Cron triggers
+### 2. Cron triggers — done (2026-08-10)
 
-`triggers` table (agent, cron expression, message template), fired by Oban
-(already a dependency), managed via API + `nornsctl triggers`. Norns is the
-system of record — composed agents have no repo for config to live in. Runs
-gain `trigger_type: "schedule"`.
+Shipped: `triggers` table (agent, cron expression, message, optional
+persistent `conversation_key`), fired by a minutely Oban job with an atomic
+per-minute claim so a trigger fires at most once per matching minute. Full
+CRUD at `/api/v1/triggers` plus `POST /triggers/:id/fire` for testing a
+trigger outside its schedule. Runs carry `trigger_type: "schedule"`. Norns is
+the system of record — composed agents have no repo for config to live in.
+Remaining: `nornsctl triggers` subcommands (separate repo).
 
 ### 3. Gards Phase 1
 

--- a/lib/norns/agents/process.ex
+++ b/lib/norns/agents/process.ex
@@ -34,11 +34,13 @@ defmodule Norns.Agents.Process do
     * `:context` — extra context map merged into the run input
     * `:parent_run_id` / `:depth` — lineage, set when this run is a sub-agent
       launched by another run. Absent for user-initiated runs.
+    * `:trigger_type` — what started the run: `"message"` (default) or
+      `"schedule"` (cron trigger).
   """
   def send_message(pid, content, opts \\ []) when is_binary(content) do
     lineage =
       opts
-      |> Keyword.take([:context, :parent_run_id, :depth])
+      |> Keyword.take([:context, :parent_run_id, :depth, :trigger_type])
       |> Keyword.put_new(:depth, 0)
 
     GenServer.call(pid, {:send_message, content, lineage}, 10_000)
@@ -129,7 +131,7 @@ defmodule Norns.Agents.Process do
         agent_id: state.agent_id,
         tenant_id: state.tenant_id,
         conversation_id: state.conversation && state.conversation.id,
-        trigger_type: "message",
+        trigger_type: Keyword.get(opts, :trigger_type, "message"),
         input: input,
         status: "pending",
         parent_run_id: Keyword.get(opts, :parent_run_id),

--- a/lib/norns/agents/registry.ex
+++ b/lib/norns/agents/registry.ex
@@ -38,7 +38,11 @@ defmodule Norns.Agents.Registry do
 
     case ensure_started(agent_id, tenant_id, conversation_key, opts) do
       {:ok, pid} ->
-        AgentProcess.send_message(pid, content, Keyword.take(opts, [:context, :parent_run_id, :depth]))
+        AgentProcess.send_message(
+          pid,
+          content,
+          Keyword.take(opts, [:context, :parent_run_id, :depth, :trigger_type])
+        )
 
       {:error, reason} ->
         {:error, reason}

--- a/lib/norns/triggers.ex
+++ b/lib/norns/triggers.ex
@@ -1,0 +1,117 @@
+defmodule Norns.Triggers do
+  @moduledoc """
+  Cron triggers: schedules that start runs on agents.
+
+  Norns is the system of record for schedules. A minutely Oban job
+  (`Norns.Workers.TriggerScheduler`) calls `fire_due/1`; each due trigger is
+  claimed by an atomic `last_fired_at` update so it fires at most once per
+  matching minute, then a run starts on the mapped agent with
+  `trigger_type: "schedule"`.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Norns.Repo
+  alias Norns.Triggers.Trigger
+  alias Norns.Agents.Registry
+
+  def list_triggers(tenant_id) do
+    Repo.all(from t in Trigger, where: t.tenant_id == ^tenant_id, order_by: t.id)
+  end
+
+  def list_triggers(tenant_id, agent_id) do
+    Repo.all(
+      from t in Trigger,
+        where: t.tenant_id == ^tenant_id and t.agent_id == ^agent_id,
+        order_by: t.id
+    )
+  end
+
+  def get_trigger(tenant_id, id) do
+    Repo.get_by(Trigger, id: id, tenant_id: tenant_id)
+  end
+
+  def create_trigger(attrs) do
+    %Trigger{}
+    |> Trigger.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_trigger(%Trigger{} = trigger, attrs) do
+    trigger
+    |> Trigger.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def delete_trigger(%Trigger{} = trigger) do
+    Repo.delete(trigger)
+  end
+
+  @doc """
+  Fire every enabled trigger whose cron matches `minute` (a UTC datetime,
+  truncated to the minute by the caller).
+
+  Firing is claim-then-run: `last_fired_at` is advanced with a conditional
+  update before the run starts, so a retried or concurrently-running
+  scheduler cannot double-fire. Returns `{fired, skipped}` counts.
+  """
+  def fire_due(minute) do
+    triggers = Repo.all(from t in Trigger, where: t.enabled == true)
+
+    Enum.reduce(triggers, {0, 0}, fn trigger, {fired, skipped} ->
+      with {:ok, expr} <- parse_cron(trigger),
+           true <- Oban.Cron.Expression.now?(expr, minute),
+           :claimed <- claim(trigger, minute),
+           {:ok, _run_id} <- fire(trigger) do
+        {fired + 1, skipped}
+      else
+        false -> {fired, skipped}
+        :already_fired -> {fired, skipped}
+        {:error, reason} ->
+          Logger.warning("Trigger #{trigger.id} (#{trigger.name}) did not fire: #{inspect(reason)}")
+          {fired, skipped + 1}
+      end
+    end)
+  end
+
+  @doc """
+  Fire a trigger immediately, outside its schedule. Does not touch
+  `last_fired_at` — a manual test firing shouldn't eat the next scheduled one.
+  Returns `{:ok, run_id}` or `{:error, reason}`.
+  """
+  def fire(%Trigger{} = trigger) do
+    opts = [trigger_type: "schedule"]
+
+    opts =
+      if trigger.conversation_key,
+        do: Keyword.put(opts, :conversation_key, trigger.conversation_key),
+        else: opts
+
+    Registry.send_message(trigger.tenant_id, trigger.agent_id, trigger.message, opts)
+  end
+
+  defp parse_cron(trigger) do
+    case Oban.Cron.Expression.parse(trigger.cron) do
+      {:ok, expr} -> {:ok, expr}
+      {:error, _} -> {:error, :invalid_cron}
+    end
+  end
+
+  # Atomic claim: only one scheduler run wins a given minute. `last_fired_at`
+  # strictly before the minute (or never) is claimable; anything else means a
+  # concurrent or earlier scheduler already fired this minute.
+  defp claim(trigger, minute) do
+    query =
+      from t in Trigger,
+        where:
+          t.id == ^trigger.id and t.enabled == true and
+            (is_nil(t.last_fired_at) or t.last_fired_at < ^minute)
+
+    case Repo.update_all(query, set: [last_fired_at: minute, updated_at: DateTime.utc_now()]) do
+      {1, _} -> :claimed
+      {0, _} -> :already_fired
+    end
+  end
+end

--- a/lib/norns/triggers/trigger.ex
+++ b/lib/norns/triggers/trigger.ex
@@ -1,0 +1,54 @@
+defmodule Norns.Triggers.Trigger do
+  @moduledoc """
+  A cron schedule that starts a run on an agent.
+
+  Triggers are Norns data, not worker config — a composed agent has no repo
+  for a schedule to live in (see `docs/plan-agent-builder.md`). The `cron`
+  field is a standard five-field expression (or an `@daily`-style alias),
+  validated with `Oban.Cron.Expression`. `message` is the content the run
+  starts with, as if a user had sent it.
+
+  `conversation_key` is optional: unset, every firing starts a fresh
+  conversation (task mode); set, firings share persistent history under that
+  key. `last_fired_at` is the dedupe claim — a trigger fires at most once per
+  matching minute, no matter how many schedulers observe it.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "triggers" do
+    field :name, :string
+    field :cron, :string
+    field :message, :string
+    field :conversation_key, :string
+    field :enabled, :boolean, default: true
+    field :last_fired_at, :utc_datetime_usec
+
+    belongs_to :tenant, Norns.Tenants.Tenant
+    belongs_to :agent, Norns.Agents.Agent
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(trigger, attrs) do
+    trigger
+    |> cast(attrs, [:tenant_id, :agent_id, :name, :cron, :message, :conversation_key, :enabled])
+    |> validate_required([:tenant_id, :agent_id, :name, :cron, :message])
+    |> validate_cron()
+    |> unique_constraint([:tenant_id, :name])
+    |> foreign_key_constraint(:agent_id)
+  end
+
+  defp validate_cron(changeset) do
+    validate_change(changeset, :cron, fn :cron, cron ->
+      case Oban.Cron.Expression.parse(cron) do
+        {:ok, _} -> []
+        {:error, %{message: message}} -> [cron: message]
+        {:error, _} -> [cron: "is not a valid cron expression"]
+      end
+    end)
+  rescue
+    _ -> add_error(changeset, :cron, "is not a valid cron expression")
+  end
+end

--- a/lib/norns/workers/trigger_scheduler.ex
+++ b/lib/norns/workers/trigger_scheduler.ex
@@ -1,0 +1,21 @@
+defmodule Norns.Workers.TriggerScheduler do
+  @moduledoc """
+  Minutely Oban job that fires due cron triggers.
+
+  The Cron plugin enqueues this every minute (`config.exs`); the actual
+  per-trigger dedupe lives in `Norns.Triggers.fire_due/1`, so an overlapping
+  or retried job cannot double-fire. `max_attempts: 1` — a missed minute is
+  a missed firing, not something to replay late against a fresh minute.
+  """
+
+  use Oban.Worker, queue: :default, max_attempts: 1
+
+  alias Norns.Triggers
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    minute = %{DateTime.utc_now() | second: 0, microsecond: {0, 6}}
+    {_fired, _skipped} = Triggers.fire_due(minute)
+    :ok
+  end
+end

--- a/lib/norns_web/controllers/trigger_controller.ex
+++ b/lib/norns_web/controllers/trigger_controller.ex
@@ -1,0 +1,105 @@
+defmodule NornsWeb.TriggerController do
+  use NornsWeb, :controller
+
+  alias Norns.Triggers
+
+  def index(conn, params) do
+    tenant = conn.assigns.current_tenant
+
+    triggers =
+      case Map.get(params, "agent_id") do
+        nil -> Triggers.list_triggers(tenant.id)
+        agent_id -> Triggers.list_triggers(tenant.id, agent_id)
+      end
+
+    json(conn, %{data: Enum.map(triggers, &NornsWeb.JSON.trigger/1)})
+  end
+
+  def create(conn, params) do
+    tenant = conn.assigns.current_tenant
+    attrs = Map.put(params, "tenant_id", tenant.id)
+
+    case Triggers.create_trigger(attrs) do
+      {:ok, trigger} ->
+        conn |> put_status(201) |> json(%{data: NornsWeb.JSON.trigger(trigger)})
+
+      {:error, changeset} ->
+        conn |> put_status(422) |> json(%{error: format_errors(changeset)})
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    tenant = conn.assigns.current_tenant
+
+    with {:ok, trigger} <- fetch_trigger(tenant.id, id) do
+      json(conn, %{data: NornsWeb.JSON.trigger(trigger)})
+    end
+  end
+
+  def update(conn, %{"id" => id} = params) do
+    tenant = conn.assigns.current_tenant
+
+    with {:ok, trigger} <- fetch_trigger(tenant.id, id) do
+      attrs = Map.drop(params, ["id", "tenant_id", "agent_id", "last_fired_at"])
+
+      case Triggers.update_trigger(trigger, attrs) do
+        {:ok, trigger} ->
+          json(conn, %{data: NornsWeb.JSON.trigger(trigger)})
+
+        {:error, changeset} ->
+          conn |> put_status(422) |> json(%{error: format_errors(changeset)})
+      end
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    tenant = conn.assigns.current_tenant
+
+    with {:ok, trigger} <- fetch_trigger(tenant.id, id) do
+      {:ok, _} = Triggers.delete_trigger(trigger)
+      send_resp(conn, 204, "")
+    end
+  end
+
+  # Fire outside the schedule — the builder loop's "test it now" without
+  # waiting for Friday. Doesn't consume the next scheduled firing.
+  def fire(conn, %{"trigger_id" => id}) do
+    tenant = conn.assigns.current_tenant
+
+    with {:ok, trigger} <- fetch_trigger(tenant.id, id) do
+      case Triggers.fire(trigger) do
+        {:ok, run_id} -> conn |> put_status(202) |> json(%{status: "accepted", run_id: run_id})
+        {:error, :busy} -> conn |> put_status(409) |> json(%{error: "agent is busy"})
+        {:error, reason} -> conn |> put_status(500) |> json(%{error: inspect(reason)})
+      end
+    end
+  end
+
+  defp fetch_trigger(tenant_id, id) do
+    case Triggers.get_trigger(tenant_id, id) do
+      nil -> {:error, :not_found}
+      trigger -> {:ok, trigger}
+    end
+  end
+
+  defp format_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
+
+  # Override action/2 to handle {:error, :not_found} from with clauses
+  def action(conn, _) do
+    args = [conn, conn.params]
+
+    case apply(__MODULE__, action_name(conn), args) do
+      {:error, :not_found} ->
+        conn |> put_status(404) |> json(%{error: "not found"})
+
+      conn ->
+        conn
+    end
+  end
+end

--- a/lib/norns_web/json.ex
+++ b/lib/norns_web/json.ex
@@ -38,6 +38,21 @@ defmodule NornsWeb.JSON do
     }
   end
 
+  def trigger(trigger) do
+    %{
+      id: trigger.id,
+      agent_id: trigger.agent_id,
+      name: trigger.name,
+      cron: trigger.cron,
+      message: trigger.message,
+      conversation_key: trigger.conversation_key,
+      enabled: trigger.enabled,
+      last_fired_at: trigger.last_fired_at,
+      inserted_at: trigger.inserted_at,
+      updated_at: trigger.updated_at
+    }
+  end
+
   def tool(tool) do
     %{
       name: tool.name,

--- a/lib/norns_web/router.ex
+++ b/lib/norns_web/router.ex
@@ -51,6 +51,10 @@ defmodule NornsWeb.Router do
 
     get "/tools", ToolController, :index
 
+    resources "/triggers", TriggerController, only: [:create, :index, :show, :update, :delete] do
+      post "/fire", TriggerController, :fire
+    end
+
     get "/runs", RunController, :index
     get "/runs/:id", RunController, :show
     get "/runs/:id/events", RunController, :events

--- a/priv/repo/migrations/20260810000100_create_triggers.exs
+++ b/priv/repo/migrations/20260810000100_create_triggers.exs
@@ -1,0 +1,23 @@
+defmodule Norns.Repo.Migrations.CreateTriggers do
+  use Ecto.Migration
+
+  def change do
+    create table(:triggers) do
+      add :tenant_id, references(:tenants), null: false
+      add :agent_id, references(:agents), null: false
+      add :name, :string, null: false
+      add :cron, :string, null: false
+      add :message, :text, null: false
+      add :conversation_key, :string
+      add :enabled, :boolean, default: true, null: false
+      add :last_fired_at, :utc_datetime_usec
+
+      timestamps()
+    end
+
+    create index(:triggers, [:tenant_id])
+    create index(:triggers, [:tenant_id, :agent_id])
+    create unique_index(:triggers, [:tenant_id, :name])
+    create index(:triggers, [:enabled])
+  end
+end

--- a/test/norns/triggers_test.exs
+++ b/test/norns/triggers_test.exs
@@ -1,0 +1,182 @@
+defmodule Norns.TriggersTest do
+  use Norns.DataCase, async: false
+
+  alias Norns.{Runs, Triggers}
+  alias Norns.LLM.Fake
+
+  setup do
+    tenant = create_tenant()
+    agent = create_agent(tenant)
+    %{tenant: tenant, agent: agent}
+  end
+
+  defp trigger_attrs(tenant, agent, attrs \\ %{}) do
+    Map.merge(
+      %{
+        tenant_id: tenant.id,
+        agent_id: agent.id,
+        name: "trigger-#{System.unique_integer([:positive])}",
+        cron: "* * * * *",
+        message: "do the thing"
+      },
+      attrs
+    )
+  end
+
+  defp minute(datetime \\ DateTime.utc_now()) do
+    %{datetime | second: 0, microsecond: {0, 6}}
+  end
+
+  defp await_run_completion(agent_id) do
+    Phoenix.PubSub.subscribe(Norns.PubSub, "agent:#{agent_id}")
+
+    receive do
+      {:completed, _} -> :ok
+      {:error, _} -> :ok
+    after
+      5000 -> flunk("run did not finish")
+    end
+  end
+
+  describe "create_trigger/1" do
+    test "creates with a valid cron expression", %{tenant: tenant, agent: agent} do
+      assert {:ok, trigger} = Triggers.create_trigger(trigger_attrs(tenant, agent, %{cron: "0 9 * * 5"}))
+      assert trigger.enabled == true
+      assert trigger.last_fired_at == nil
+    end
+
+    test "accepts cron aliases", %{tenant: tenant, agent: agent} do
+      assert {:ok, _} = Triggers.create_trigger(trigger_attrs(tenant, agent, %{cron: "@daily"}))
+    end
+
+    test "rejects an invalid cron expression", %{tenant: tenant, agent: agent} do
+      for bad <- ["not cron", "* * *", "99 * * * *"] do
+        assert {:error, changeset} = Triggers.create_trigger(trigger_attrs(tenant, agent, %{cron: bad}))
+        assert Keyword.has_key?(changeset.errors, :cron)
+      end
+    end
+
+    test "names are unique per tenant", %{tenant: tenant, agent: agent} do
+      attrs = trigger_attrs(tenant, agent, %{name: "friday-report"})
+      assert {:ok, _} = Triggers.create_trigger(attrs)
+      assert {:error, changeset} = Triggers.create_trigger(attrs)
+      assert Keyword.has_key?(changeset.errors, :tenant_id) or match?([_ | _], changeset.errors)
+    end
+  end
+
+  describe "listing and lookup" do
+    test "list and get are tenant-scoped", %{tenant: tenant, agent: agent} do
+      other_tenant = create_tenant()
+      other_agent = create_agent(other_tenant)
+
+      {:ok, mine} = Triggers.create_trigger(trigger_attrs(tenant, agent))
+      {:ok, theirs} = Triggers.create_trigger(trigger_attrs(other_tenant, other_agent))
+
+      assert Enum.map(Triggers.list_triggers(tenant.id), & &1.id) == [mine.id]
+      assert Triggers.get_trigger(tenant.id, theirs.id) == nil
+    end
+  end
+
+  describe "fire_due/1" do
+    test "fires a due trigger and stamps the run as schedule-triggered", %{tenant: tenant, agent: agent} do
+      Fake.set_responses([
+        %{content: [%{"type" => "text", "text" => "posted"}], stop_reason: "end_turn"}
+      ])
+
+      {:ok, trigger} = Triggers.create_trigger(trigger_attrs(tenant, agent, %{message: "post the report"}))
+
+      now = minute()
+      assert {1, 0} = Triggers.fire_due(now)
+      await_run_completion(agent.id)
+
+      [run] = Runs.list_runs(agent.id)
+      assert run.trigger_type == "schedule"
+      assert run.input["user_message"] == "post the report"
+
+      assert Triggers.get_trigger(tenant.id, trigger.id).last_fired_at == now
+    end
+
+    test "a trigger fires at most once per minute", %{tenant: tenant, agent: agent} do
+      Fake.set_responses([
+        %{content: [%{"type" => "text", "text" => "posted"}], stop_reason: "end_turn"}
+      ])
+
+      {:ok, _} = Triggers.create_trigger(trigger_attrs(tenant, agent))
+
+      now = minute()
+      assert {1, 0} = Triggers.fire_due(now)
+      await_run_completion(agent.id)
+      assert {0, 0} = Triggers.fire_due(now)
+
+      assert length(Runs.list_runs(agent.id)) == 1
+    end
+
+    test "fires again in a later minute", %{tenant: tenant, agent: agent} do
+      Fake.set_responses([
+        %{content: [%{"type" => "text", "text" => "one"}], stop_reason: "end_turn"},
+        %{content: [%{"type" => "text", "text" => "two"}], stop_reason: "end_turn"}
+      ])
+
+      {:ok, _} = Triggers.create_trigger(trigger_attrs(tenant, agent))
+
+      now = minute()
+      assert {1, 0} = Triggers.fire_due(now)
+      await_run_completion(agent.id)
+
+      assert {1, 0} = Triggers.fire_due(DateTime.add(now, 60, :second))
+      await_run_completion(agent.id)
+
+      assert length(Runs.list_runs(agent.id)) == 2
+    end
+
+    test "skips disabled and non-matching triggers", %{tenant: tenant, agent: agent} do
+      {:ok, _} = Triggers.create_trigger(trigger_attrs(tenant, agent, %{enabled: false}))
+
+      # 9am Friday only — fire_due at a known non-matching minute
+      {:ok, _} = Triggers.create_trigger(trigger_attrs(tenant, agent, %{cron: "0 9 * * 5"}))
+      not_friday = %{DateTime.new!(~D[2026-08-10], ~T[10:30:00], "Etc/UTC") | microsecond: {0, 6}}
+
+      assert {0, 0} = Triggers.fire_due(not_friday)
+      assert Runs.list_runs(agent.id) == []
+    end
+  end
+
+  describe "fire/1" do
+    test "manual fire does not consume the scheduled minute", %{tenant: tenant, agent: agent} do
+      Fake.set_responses([
+        %{content: [%{"type" => "text", "text" => "one"}], stop_reason: "end_turn"},
+        %{content: [%{"type" => "text", "text" => "two"}], stop_reason: "end_turn"}
+      ])
+
+      {:ok, trigger} = Triggers.create_trigger(trigger_attrs(tenant, agent))
+
+      assert {:ok, _run_id} = Triggers.fire(trigger)
+      await_run_completion(agent.id)
+      assert Triggers.get_trigger(tenant.id, trigger.id).last_fired_at == nil
+
+      assert {1, 0} = Triggers.fire_due(minute())
+      await_run_completion(agent.id)
+
+      assert length(Runs.list_runs(agent.id)) == 2
+    end
+
+    test "a persistent conversation_key keeps history across firings", %{tenant: tenant, agent: agent} do
+      Fake.set_responses([
+        %{content: [%{"type" => "text", "text" => "one"}], stop_reason: "end_turn"},
+        %{content: [%{"type" => "text", "text" => "two"}], stop_reason: "end_turn"}
+      ])
+
+      {:ok, trigger} =
+        Triggers.create_trigger(trigger_attrs(tenant, agent, %{conversation_key: "report-thread"}))
+
+      {:ok, _} = Triggers.fire(trigger)
+      await_run_completion(agent.id)
+      {:ok, _} = Triggers.fire(trigger)
+      await_run_completion(agent.id)
+
+      [_first, second] = Fake.calls()
+      # Second firing sees the first firing's history: user, assistant, user
+      assert length(second.messages) == 3
+    end
+  end
+end

--- a/test/norns_web/controllers/trigger_controller_test.exs
+++ b/test/norns_web/controllers/trigger_controller_test.exs
@@ -1,0 +1,127 @@
+defmodule NornsWeb.TriggerControllerTest do
+  use NornsWeb.ConnCase, async: false
+
+  alias Norns.LLM.Fake
+
+  setup %{conn: conn} do
+    tenant = create_tenant()
+    agent = create_agent(tenant)
+    conn = authenticated_conn(conn, tenant)
+    %{conn: conn, tenant: tenant, agent: agent}
+  end
+
+  defp valid_params(agent, attrs \\ %{}) do
+    Map.merge(
+      %{
+        "agent_id" => agent.id,
+        "name" => "trigger-#{System.unique_integer([:positive])}",
+        "cron" => "0 9 * * 5",
+        "message" => "post the weekly report"
+      },
+      attrs
+    )
+  end
+
+  describe "POST /api/v1/triggers" do
+    test "creates a trigger", %{conn: conn, agent: agent} do
+      conn = post(conn, "/api/v1/triggers", valid_params(agent, %{"name" => "friday-report"}))
+
+      assert %{"data" => data} = json_response(conn, 201)
+      assert data["name"] == "friday-report"
+      assert data["cron"] == "0 9 * * 5"
+      assert data["enabled"] == true
+      assert data["agent_id"] == agent.id
+    end
+
+    test "rejects an invalid cron expression", %{conn: conn, agent: agent} do
+      conn = post(conn, "/api/v1/triggers", valid_params(agent, %{"cron" => "whenever"}))
+      assert %{"error" => %{"cron" => _}} = json_response(conn, 422)
+    end
+
+    test "rejects missing fields", %{conn: conn, agent: agent} do
+      conn = post(conn, "/api/v1/triggers", %{"agent_id" => agent.id})
+      assert %{"error" => _} = json_response(conn, 422)
+    end
+  end
+
+  describe "GET /api/v1/triggers" do
+    test "lists tenant triggers, optionally filtered by agent", %{conn: conn, tenant: tenant, agent: agent} do
+      other_agent = create_agent(tenant)
+      post(conn, "/api/v1/triggers", valid_params(agent))
+      post(conn, "/api/v1/triggers", valid_params(other_agent))
+
+      assert %{"data" => all} = json_response(get(conn, "/api/v1/triggers"), 200)
+      assert length(all) == 2
+
+      assert %{"data" => [only]} =
+               json_response(get(conn, "/api/v1/triggers?agent_id=#{agent.id}"), 200)
+
+      assert only["agent_id"] == agent.id
+    end
+
+    test "does not leak another tenant's triggers", %{conn: conn} do
+      other_tenant = create_tenant()
+      other_agent = create_agent(other_tenant)
+
+      {:ok, other_trigger} =
+        Norns.Triggers.create_trigger(%{
+          tenant_id: other_tenant.id,
+          agent_id: other_agent.id,
+          name: "theirs",
+          cron: "@daily",
+          message: "hi"
+        })
+
+      assert %{"data" => []} = json_response(get(conn, "/api/v1/triggers"), 200)
+      assert json_response(get(conn, "/api/v1/triggers/#{other_trigger.id}"), 404)
+    end
+  end
+
+  describe "PATCH /api/v1/triggers/:id" do
+    test "updates and can disable a trigger", %{conn: conn, agent: agent} do
+      %{"data" => %{"id" => id}} =
+        json_response(post(conn, "/api/v1/triggers", valid_params(agent)), 201)
+
+      conn = patch(conn, "/api/v1/triggers/#{id}", %{"enabled" => false, "cron" => "@hourly"})
+
+      assert %{"data" => data} = json_response(conn, 200)
+      assert data["enabled"] == false
+      assert data["cron"] == "@hourly"
+    end
+  end
+
+  describe "DELETE /api/v1/triggers/:id" do
+    test "deletes a trigger", %{conn: conn, agent: agent} do
+      %{"data" => %{"id" => id}} =
+        json_response(post(conn, "/api/v1/triggers", valid_params(agent)), 201)
+
+      assert response(delete(conn, "/api/v1/triggers/#{id}"), 204)
+      assert json_response(get(conn, "/api/v1/triggers/#{id}"), 404)
+    end
+  end
+
+  describe "POST /api/v1/triggers/:id/fire" do
+    test "starts a run immediately", %{conn: conn, agent: agent} do
+      Fake.set_responses([
+        %{content: [%{"type" => "text", "text" => "done"}], stop_reason: "end_turn"}
+      ])
+
+      %{"data" => %{"id" => id}} =
+        json_response(post(conn, "/api/v1/triggers", valid_params(agent)), 201)
+
+      Phoenix.PubSub.subscribe(Norns.PubSub, "agent:#{agent.id}")
+      conn = post(conn, "/api/v1/triggers/#{id}/fire")
+
+      assert %{"status" => "accepted", "run_id" => run_id} = json_response(conn, 202)
+
+      receive do
+        {:completed, _} -> :ok
+      after
+        5000 -> flunk("run did not complete")
+      end
+
+      run = Norns.Runs.get_run!(run_id)
+      assert run.trigger_type == "schedule"
+    end
+  end
+end


### PR DESCRIPTION
Roadmap step 2: schedules as first-class Norns data. A composed agent has no repo for trigger config to live in, so Norns is the system of record.

## What

- **`triggers` table + `Norns.Triggers` context** — agent, cron expression (validated with `Oban.Cron.Expression` at write time, aliases like `@daily` supported), message, optional `conversation_key`, `enabled` flag.
- **Firing**: the Oban Cron plugin enqueues `Norns.Workers.TriggerScheduler` every minute. Dedupe is an atomic `last_fired_at` claim (`UPDATE ... WHERE last_fired_at < minute`), so a trigger fires at most once per matching minute even with overlapping or retried schedulers.
- **Runs carry `trigger_type: "schedule"`** — plumbed through `Registry.send_message` → `Process.send_message` opts.
- **Conversation semantics**: default is task mode (fresh conversation per firing, which also avoids busy collisions with a still-running previous firing); setting `conversation_key` opts into persistent history across firings.
- **API**: full CRUD at `/api/v1/triggers` (list filterable by `agent_id`), plus `POST /api/v1/triggers/:id/fire` to test a trigger outside its schedule — a manual firing does not consume the next scheduled one.

## Tests

19 new tests: cron validation (including junk and out-of-range fields), tenant scoping, at-most-once-per-minute claim, re-firing on the next minute, disabled/non-matching skips, manual fire not eating the scheduled minute, persistent-conversation history, controller CRUD + cross-tenant 404s + fire endpoint. Full suite: 243 tests, 0 failures, `--warnings-as-errors` and credo clean.

Docs updated: roadmap step 2 marked done, decision log Implemented entry, agent-builder plan updated. `nornsctl triggers` subcommands are follow-up work in the nornsctl repo.