### PR TITLE
Gards Phase 1: worker affinity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ lib/norns/
   conversations/    — Conversation schema + context (persistent chat history)
   runs/             — Run + RunEvent schemas, Runs context (event log)
   runtime/          — Event contracts, error taxonomy, retry policy
+  gards/            — Gard + GardPort schemas; Gards context (worker affinity)
   triggers/         — Trigger schema + context (cron schedules that start runs)
   workers/          — WorkerRegistry, TaskQueue, ResumeAgents, TriggerScheduler
   llm.ex            — LLM dispatcher (used by workers via Fake in tests)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ lib/norns/
   conversations/    — Conversation schema + context (persistent chat history)
   runs/             — Run + RunEvent schemas, Runs context (event log)
   runtime/          — Event contracts, error taxonomy, retry policy
+  gards/            — Gard + GardPort schemas; Gards context (worker affinity)
   triggers/         — Trigger schema + context (cron schedules that start runs)
   workers/          — WorkerRegistry, TaskQueue, ResumeAgents, TriggerScheduler
   llm.ex            — LLM dispatcher (used by workers via Fake in tests)

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -120,6 +120,14 @@ Last updated: 2026-08-10
 - Runs started by a trigger carry `trigger_type: "schedule"`. Cron expressions validated with `Oban.Cron.Expression` at write time.
 - Default is task mode (fresh conversation per firing); setting `conversation_key` opts into shared history across firings.
 
+### Gards Phase 1 (core)
+- `Norns.Gards` — gard registry with server-generated 256-bit claim tokens, atomic claim (one winner among simultaneous claimants), idempotent disconnect marking, soft-delete destroy with active-run guard and worker kick.
+- Dispatch is gard-strict end to end: `find_worker` strict equality, `available_tools` gard-filtered, TaskQueue flush matches `{tenant, tool, gard}`. LLM dispatch deliberately unfiltered (no filesystem affinity).
+- Gard binds per-run (`send_message gard_id:`), children inherit the parent's gard, resume restores affinity from the run row, idempotency keys include the gard (no-gard keys keep the historical shape, so pre-gard runs replay correctly).
+- The disconnect status write runs in an isolated task — a database hiccup must not crash the registry that holds every worker connection.
+- REST: gard CRUD (claim token returned exactly once, on create) + ports; workers register ports over their channel, gard inferred from the connection.
+- Remaining Phase 1 surface: `nornsctl gard`, dashboard page, Python SDK support.
+
 ### Sub-agent crash recovery
 - A resumed parent reattaches to its in-flight child by run id instead of relaunching it — a pending `launch_agent` is a reference to work already underway, not a request.
 - Subscribe-before-read closes the completion race; `run_id` rides on every agent broadcast; a parent resumed alone restarts its own orphaned child.

--- a/docs/gards.md
+++ b/docs/gards.md
@@ -1,6 +1,6 @@
 # Norns Gards — Design Document
 
-## Status: Draft (v6) — Phase 1 is next up (`roadmap.md` step 3); the provisioner is on the critical path per the fork decision in `decision-log.md`, and its first product is managed connectors (§ The cloud boundary)
+## Status: v7 — Phase 1 core shipped 2026-08-10 (registry, claims, strict dispatch, per-run binding, API; `nornsctl`/dashboard/Python SDK still open). The provisioner is on the critical path per the fork decision in `decision-log.md`, and its first product is managed connectors (§ The cloud boundary)
 
 ## Summary
 

--- a/docs/plan-agent-builder.md
+++ b/docs/plan-agent-builder.md
@@ -1,7 +1,7 @@
 # Plan: Agent Builder
 
 **Status:** Direction agreed (2026-08-08); cloud boundary decided (2026-08-10) — builder ships as a Norns Cloud product, sequencing in `roadmap.md`
-**Depends on:** per-agent tool selection (shipped 2026-08-10), cron triggers (shipped 2026-08-10), gards Phase 1 (`gards.md`)
+**Depends on:** per-agent tool selection (shipped 2026-08-10), cron triggers (shipped 2026-08-10), gards Phase 1 (core shipped 2026-08-10, `gards.md`)
 
 The product direction: a builder that turns "create a Slack bot that posts the
 current call count to #general every Friday" into a running, durable agent.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,7 +55,7 @@ builder later composes against.
 flowchart TB
     A["1 — Per-agent tool selection ✓<br/>ToolPolicy on AgentDef — shipped 2026-08-10"]
     B["2 — Cron triggers ✓<br/>triggers table · Oban · API — shipped 2026-08-10"]
-    C["3 — Gards Phase 1<br/>registry + dispatch filter (+ secrets requirement)"]
+    C["3 — Gards Phase 1 ✓<br/>registry + dispatch filter — core shipped 2026-08-10"]
     D["4 — Fabricate toolkit<br/>templates · scaffold AGENTS.md · nornsctl --wait"]
     E["5 — Inbound webhooks<br/>POST /api/v1/hooks/:token · signature verification"]
     F["6 — Provisioner<br/>separate repo · managed connectors first, then coding-agent gards"]
@@ -81,12 +81,16 @@ the system of record — composed agents have no repo for config to live in.
 `nornsctl triggers` (list/show/create/update/enable/disable/delete/fire)
 shipped in the nornsctl repo the same day.
 
-### 3. Gards Phase 1
+### 3. Gards Phase 1 — core shipped (2026-08-10)
 
-Registry + dispatch filter, per `gards.md` — unchanged scope, two additions
-from the builder work: secrets injection (env into the gard) is a named
-provisioner requirement, and the provisioner is on the critical path rather
-than optional.
+Registry + dispatch filter, per `gards.md`: `gards`/`gard_ports` tables,
+atomic claim tokens, strict-equality dispatch (no-gard runs never touch gard
+workers and vice versa), gard-filtered tool advertisement, gard-aware
+TaskQueue flush, per-run binding with child inheritance and resume-safe
+affinity, gard-scoped idempotency keys, REST CRUD + worker-channel port
+registration. Remaining from the Phase 1 list: `nornsctl gard` commands,
+the `/gards` dashboard page, and Python SDK `gard`/`claim_token` support.
+Secrets injection stays a named provisioner (Phase 2) requirement.
 
 ### 4. Fabricate toolkit
 

--- a/lib/norns/agents/process.ex
+++ b/lib/norns/agents/process.ex
@@ -36,11 +36,13 @@ defmodule Norns.Agents.Process do
       launched by another run. Absent for user-initiated runs.
     * `:trigger_type` — what started the run: `"message"` (default) or
       `"schedule"` (cron trigger).
+    * `:gard_id` — bind this run to a gard: all tool dispatch goes only to
+      workers in that gard. Per-run, not per-process.
   """
   def send_message(pid, content, opts \\ []) when is_binary(content) do
     lineage =
       opts
-      |> Keyword.take([:context, :parent_run_id, :depth, :trigger_type])
+      |> Keyword.take([:context, :parent_run_id, :depth, :trigger_type, :gard_id])
       |> Keyword.put_new(:depth, 0)
 
     GenServer.call(pid, {:send_message, content, lineage}, 10_000)
@@ -102,6 +104,7 @@ defmodule Norns.Agents.Process do
       task_timer: nil,
       pending_subagents: %{},
       pending_human: nil,
+      gard_id: nil,
       resume_action: nil,
       test_pid: Keyword.get(opts, :test_pid),
       input_tokens: 0,
@@ -120,6 +123,7 @@ defmodule Norns.Agents.Process do
   @impl true
   def handle_call({:send_message, content, opts}, _from, %{status: :idle} = state) do
     context = Keyword.get(opts, :context)
+    gard_id = Keyword.get(opts, :gard_id)
     state = load_conversation_state(state)
     messages = messages_for_new_run(state, content, context)
 
@@ -135,13 +139,14 @@ defmodule Norns.Agents.Process do
         input: input,
         status: "pending",
         parent_run_id: Keyword.get(opts, :parent_run_id),
-        depth: Keyword.get(opts, :depth, 0)
+        depth: Keyword.get(opts, :depth, 0),
+        gard_id: gard_id
       })
 
     append(run, Events.run_started())
     {:ok, run} = Runs.update_run(run, %{status: "running"})
 
-    state = %{state | run: run, messages: messages, step: 0, retry_count: 0, status: :running, resume_action: nil}
+    state = %{state | run: run, messages: messages, step: 0, retry_count: 0, status: :running, gard_id: gard_id, resume_action: nil}
 
     broadcast(state, :agent_started, %{run_id: run.id})
     {:reply, {:ok, run.id}, state, {:continue, :llm_loop}}
@@ -235,7 +240,12 @@ defmodule Norns.Agents.Process do
       policy = state.agent_def.tool_policy
       builtin_tools = Builtins.all()
       agent_tools = ToolPolicy.filter(policy, state.agent_def.tools)
-      worker_tools = ToolPolicy.filter(policy, WorkerRegistry.available_tools(state.tenant_id))
+
+      worker_tools =
+        ToolPolicy.filter(
+          policy,
+          WorkerRegistry.available_tools(state.tenant_id, gard: state.gard_id)
+        )
       all_tools = (builtin_tools ++ agent_tools ++ worker_tools) |> Enum.uniq_by(& &1.name)
       tools = Enum.map(all_tools, &Tool.to_api_format/1)
 
@@ -382,7 +392,8 @@ defmodule Norns.Agents.Process do
             WorkerRegistry.dispatch_task(state.tenant_id, tc["name"], tc["arguments"],
               from_pid: self(),
               agent_id: state.agent_id,
-              run_id: state.run.id
+              run_id: state.run.id,
+              gard: state.gard_id
             )
 
           {task_id, tc}
@@ -642,10 +653,15 @@ defmodule Norns.Agents.Process do
 
         conversation_key = "subagent_#{block["id"]}_#{System.unique_integer([:positive])}"
 
+        # A child working on the same task should see the same filesystem —
+        # inherit the parent's gard unless the call names a different one.
+        child_gard = get_in(block, ["arguments", "gard_id"]) || st.gard_id
+
         spawn_opts = [
           conversation_key: conversation_key,
           parent_run_id: st.run && st.run.id,
-          depth: child_depth
+          depth: child_depth,
+          gard_id: child_gard
         ]
 
         spawn_opts = if context, do: Keyword.put(spawn_opts, :context, context), else: spawn_opts
@@ -1311,7 +1327,10 @@ defmodule Norns.Agents.Process do
        |> Map.put(:status, :running)
        |> Map.put(:resume_action, resume_action)
        |> Map.put(:input_tokens, input_tokens)
-       |> Map.put(:output_tokens, output_tokens)}
+       |> Map.put(:output_tokens, output_tokens)
+       # The gard rides on the run row — a resumed run must keep its
+       # affinity or replayed tool dispatch would leak to no-gard workers.
+       |> Map.put(:gard_id, run.gard_id)}
     end
   end
 

--- a/lib/norns/agents/registry.ex
+++ b/lib/norns/agents/registry.ex
@@ -41,7 +41,7 @@ defmodule Norns.Agents.Registry do
         AgentProcess.send_message(
           pid,
           content,
-          Keyword.take(opts, [:context, :parent_run_id, :depth, :trigger_type])
+          Keyword.take(opts, [:context, :parent_run_id, :depth, :trigger_type, :gard_id])
         )
 
       {:error, reason} ->

--- a/lib/norns/gards.ex
+++ b/lib/norns/gards.ex
@@ -1,0 +1,150 @@
+defmodule Norns.Gards do
+  @moduledoc """
+  Gard registry: CRUD, worker claims, and port registration.
+
+  Concurrency invariants (see `docs/gards.md` § Concurrency Invariants):
+  `claim/3` is an atomic conditional UPDATE — of N simultaneous claimants
+  exactly one wins; `mark_disconnected/2` is idempotent because both the
+  unregister and DOWN paths can fire on the same disconnect; gards are
+  soft-deleted only, keeping the runs FK valid.
+  """
+
+  import Ecto.Query
+
+  alias Norns.Repo
+  alias Norns.Gards.{Gard, GardPort}
+
+  # -- CRUD --
+
+  def list_gards(tenant_id) do
+    Repo.all(from g in Gard, where: g.tenant_id == ^tenant_id, order_by: g.id)
+  end
+
+  def get_gard(tenant_id, id) when is_integer(id) do
+    Repo.get_by(Gard, id: id, tenant_id: tenant_id)
+  end
+
+  def get_gard(tenant_id, id) when is_binary(id) do
+    case Integer.parse(id) do
+      {parsed, ""} -> get_gard(tenant_id, parsed)
+      _ -> nil
+    end
+  end
+
+  def get_gard(_tenant_id, _id), do: nil
+
+  def create_gard(attrs) do
+    %Gard{}
+    |> Gard.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_gard(%Gard{} = gard, attrs) do
+    gard
+    |> Gard.update_changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Soft-destroy a gard: status → `destroyed`, ports removed, and the worker
+  currently claiming it kicked (which fails its in-flight tasks through the
+  existing disconnect path). Refuses if the gard has an active run unless
+  `force: true`.
+  """
+  def destroy(tenant_id, gard_id, opts \\ []) do
+    force = Keyword.get(opts, :force, false)
+
+    if not force and has_active_run?(gard_id) do
+      {:error, :active_run}
+    else
+      query =
+        from g in Gard,
+          where: g.id == ^gard_id and g.tenant_id == ^tenant_id and g.status != "destroyed"
+
+      case Repo.update_all(query, set: [status: "destroyed", updated_at: DateTime.utc_now()]) do
+        {1, _} ->
+          Repo.delete_all(from p in GardPort, where: p.gard_id == ^gard_id)
+          Norns.Workers.WorkerRegistry.kick_gard_workers(tenant_id, gard_id)
+          :ok
+
+        {0, _} ->
+          {:error, :not_found}
+      end
+    end
+  end
+
+  defp has_active_run?(gard_id) do
+    Repo.exists?(
+      from r in Norns.Runs.Run,
+        where: r.gard_id == ^gard_id and r.status in ["pending", "running", "waiting"]
+    )
+  end
+
+  # -- Worker claims --
+
+  @doc """
+  Claim a gard for a connecting worker.
+
+  Atomic conditional update — prevents the TOCTOU race when two workers
+  connect simultaneously: only one wins, the other gets a classified error.
+  Claimable from `pending` (first connect) and `disconnected` (reconnect).
+  """
+  def claim(tenant_id, gard_id, claim_token) when is_binary(claim_token) do
+    query =
+      from g in Gard,
+        where:
+          g.id == ^gard_id and g.tenant_id == ^tenant_id and
+            g.claim_token == ^claim_token and
+            g.status in ["pending", "disconnected"]
+
+    case Repo.update_all(query, set: [status: "ready", updated_at: DateTime.utc_now()]) do
+      {1, _} -> :ok
+      {0, _} -> classify_claim_failure(tenant_id, gard_id, claim_token)
+    end
+  end
+
+  def claim(_tenant_id, _gard_id, _claim_token), do: {:error, :invalid_claim_token}
+
+  defp classify_claim_failure(tenant_id, gard_id, claim_token) do
+    case Repo.get_by(Gard, id: gard_id, tenant_id: tenant_id) do
+      nil -> {:error, :not_found}
+      %{status: "destroyed"} -> {:error, :gard_destroyed}
+      %{status: "ready"} -> {:error, :already_claimed}
+      %{claim_token: ^claim_token} -> {:error, :already_claimed}
+      _ -> {:error, :invalid_claim_token}
+    end
+  end
+
+  @doc """
+  Mark a gard's worker as gone. Idempotent — both the unregister and DOWN
+  paths can fire on the same disconnect; only `ready` transitions, so a
+  second call (or a call after destroy) writes nothing.
+  """
+  def mark_disconnected(tenant_id, gard_id) do
+    query =
+      from g in Gard,
+        where: g.id == ^gard_id and g.tenant_id == ^tenant_id and g.status == "ready"
+
+    Repo.update_all(query, set: [status: "disconnected", updated_at: DateTime.utc_now()])
+    :ok
+  end
+
+  # -- Ports --
+
+  def list_ports(gard_id) do
+    Repo.all(from p in GardPort, where: p.gard_id == ^gard_id, order_by: p.internal_port)
+  end
+
+  def register_port(gard_id, attrs) do
+    %GardPort{}
+    |> GardPort.changeset(Map.put(attrs, "gard_id", gard_id))
+    |> Repo.insert()
+  end
+
+  def delete_port(gard_id, port_id) do
+    case Repo.get_by(GardPort, id: port_id, gard_id: gard_id) do
+      nil -> {:error, :not_found}
+      port -> Repo.delete(port)
+    end
+  end
+end

--- a/lib/norns/gards/gard.ex
+++ b/lib/norns/gards/gard.ex
@@ -1,0 +1,55 @@
+defmodule Norns.Gards.Gard do
+  @moduledoc """
+  A gard is a bounded execution context — a filesystem, a container, a VM —
+  where exactly one worker operates. Norns tracks gards and routes tool
+  dispatch to them; it never creates or manages the underlying
+  infrastructure (that's the provisioner's job — see `docs/gards.md`).
+
+  Statuses: `pending` (created, no worker yet) → `ready` (worker claimed) →
+  `disconnected` (worker gone, reconnect allowed) → `destroyed` (terminal;
+  soft-delete only, the row stays for referential integrity with runs).
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @statuses ~w(pending ready disconnected destroyed)
+
+  schema "gards" do
+    field :name, :string
+    field :status, :string, default: "pending"
+    field :template, :string
+    field :claim_token, :string
+    field :metadata, :map, default: %{}
+
+    belongs_to :tenant, Norns.Tenants.Tenant
+    has_many :ports, Norns.Gards.GardPort
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def statuses, do: @statuses
+
+  def changeset(gard, attrs) do
+    gard
+    |> cast(attrs, [:tenant_id, :name, :template, :metadata])
+    |> validate_required([:tenant_id])
+    |> put_claim_token()
+  end
+
+  def update_changeset(gard, attrs) do
+    cast(gard, attrs, [:name, :template, :metadata])
+  end
+
+  # Claim tokens are always generated server-side — never user-supplied.
+  defp put_claim_token(changeset) do
+    case get_field(changeset, :claim_token) do
+      nil ->
+        token = :crypto.strong_rand_bytes(32) |> Base.url_encode64(padding: false)
+        put_change(changeset, :claim_token, token)
+
+      _ ->
+        changeset
+    end
+  end
+end

--- a/lib/norns/gards/gard_port.ex
+++ b/lib/norns/gards/gard_port.ex
@@ -1,0 +1,47 @@
+defmodule Norns.Gards.GardPort do
+  @moduledoc """
+  A port exposed by a service running inside a gard, with the externally
+  reachable URL (localhost for local gards, a tunnel URL for remote ones).
+  Norns stores and displays these; it never proxies traffic.
+
+  Ports belong to the gard, not the worker — they survive worker
+  disconnect/reconnect and are removed only when the gard is destroyed.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  # URL schemes are restricted to prevent XSS via links rendered in the
+  # dashboard (e.g. javascript: URLs).
+  @allowed_schemes ~w(http https tcp)
+
+  schema "gard_ports" do
+    field :internal_port, :integer
+    field :url, :string
+    field :name, :string
+    field :protocol, :string, default: "http"
+
+    belongs_to :gard, Norns.Gards.Gard
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(port, attrs) do
+    port
+    |> cast(attrs, [:gard_id, :internal_port, :url, :name, :protocol])
+    |> validate_required([:gard_id, :internal_port])
+    |> validate_number(:internal_port, greater_than: 0, less_than: 65_536)
+    |> validate_inclusion(:protocol, @allowed_schemes)
+    |> validate_url_scheme()
+    |> foreign_key_constraint(:gard_id)
+  end
+
+  defp validate_url_scheme(changeset) do
+    validate_change(changeset, :url, fn :url, url ->
+      case URI.parse(url).scheme do
+        scheme when scheme in @allowed_schemes -> []
+        _ -> [url: "scheme must be one of: #{Enum.join(@allowed_schemes, ", ")}"]
+      end
+    end)
+  end
+end

--- a/lib/norns/runs/run.ex
+++ b/lib/norns/runs/run.ex
@@ -16,6 +16,7 @@ defmodule Norns.Runs.Run do
     belongs_to :agent, Norns.Agents.Agent
     belongs_to :conversation, Norns.Conversations.Conversation
     belongs_to :parent_run, Norns.Runs.Run, foreign_key: :parent_run_id
+    belongs_to :gard, Norns.Gards.Gard
     has_many :events, Norns.Runs.RunEvent
 
     timestamps(type: :utc_datetime_usec)
@@ -23,11 +24,12 @@ defmodule Norns.Runs.Run do
 
   def changeset(run, attrs) do
     run
-    |> cast(attrs, [:tenant_id, :agent_id, :conversation_id, :status, :trigger_type, :input, :output, :failure_metadata, :input_tokens, :output_tokens, :parent_run_id, :depth])
+    |> cast(attrs, [:tenant_id, :agent_id, :conversation_id, :status, :trigger_type, :input, :output, :failure_metadata, :input_tokens, :output_tokens, :parent_run_id, :depth, :gard_id])
     |> validate_required([:tenant_id, :agent_id, :status, :trigger_type])
     |> validate_inclusion(:status, ["pending", "running", "waiting", "completed", "failed"])
     |> validate_number(:depth, greater_than_or_equal_to: 0)
     |> foreign_key_constraint(:agent_id)
+    |> foreign_key_constraint(:gard_id)
     |> foreign_key_constraint(:parent_run_id)
     |> foreign_key_constraint(:conversation_id)
     |> foreign_key_constraint(:tenant_id)

--- a/lib/norns/tools/idempotency.ex
+++ b/lib/norns/tools/idempotency.ex
@@ -12,9 +12,10 @@ defmodule Norns.Tools.Idempotency do
           idempotency_key: String.t() | nil
         }
 
-  def context(%{id: run_id}, step, %{"id" => tool_call_id, "name" => tool_name} = tc, %Tool{} = tool) do
+  def context(%{id: run_id} = run, step, %{"id" => tool_call_id, "name" => tool_name} = tc, %Tool{} = tool) do
     arguments = tc["arguments"] || tc["input"] || %{}
     side_effect? = side_effecting?(tool, arguments)
+    gard_id = Map.get(run, :gard_id)
 
     %{
       run_id: run_id,
@@ -22,12 +23,24 @@ defmodule Norns.Tools.Idempotency do
       tool_call_id: tool_call_id,
       tool_name: tool_name,
       side_effect?: side_effect?,
-      idempotency_key: if(side_effect?, do: key(run_id, step, tool_call_id, tool_name), else: nil)
+      idempotency_key:
+        if(side_effect?, do: key(run_id, step, tool_call_id, tool_name, gard_id), else: nil)
     }
   end
 
-  def key(run_id, step, tool_call_id, tool_name) do
+  # The same (tool, args) in two different gards is genuinely two different
+  # operations — without the gard in the key, crash recovery could skip a call
+  # in gard B because gard A already recorded a result for it. No-gard runs
+  # keep the historical key shape, so keys stored before gards exist still
+  # match on replay.
+  def key(run_id, step, tool_call_id, tool_name, gard_id \\ nil)
+
+  def key(run_id, step, tool_call_id, tool_name, nil) do
     "run:#{run_id}:step:#{step}:tool:#{tool_call_id}:name:#{tool_name}"
+  end
+
+  def key(run_id, step, tool_call_id, tool_name, gard_id) do
+    "run:#{run_id}:step:#{step}:tool:#{tool_call_id}:name:#{tool_name}:gard:#{gard_id}"
   end
 
   def side_effecting?(%Tool{name: "http_request"}, %{"method" => method}) do

--- a/lib/norns/workers/task_queue.ex
+++ b/lib/norns/workers/task_queue.ex
@@ -18,9 +18,16 @@ defmodule Norns.Workers.TaskQueue do
     GenServer.cast(__MODULE__, {:enqueue, tenant_id, task})
   end
 
-  @doc "Flush and return all queued tasks for a tool name."
-  def flush(tenant_id, tool_name) do
-    GenServer.call(__MODULE__, {:flush, tenant_id, tool_name})
+  @doc """
+  Flush and return all queued tasks for a tool name.
+
+  Pass `gard:` to match strictly on the task's gard (nil matches only
+  no-gard tasks) — a queued gard-bound task must never flush to a worker in
+  a different gard. Without the option, gard is ignored (LLM tasks have no
+  filesystem affinity).
+  """
+  def flush(tenant_id, tool_name, opts \\ []) do
+    GenServer.call(__MODULE__, {:flush, tenant_id, tool_name, opts})
   end
 
   @doc "Get queue depth for a tenant (for monitoring)."
@@ -45,9 +52,16 @@ defmodule Norns.Workers.TaskQueue do
   end
 
   @impl true
-  def handle_call({:flush, tenant_id, tool_name}, _from, state) do
+  def handle_call({:flush, tenant_id, tool_name, opts}, _from, state) do
     queue = Map.get(state.queues, tenant_id, [])
-    {matching, remaining} = Enum.split_with(queue, &(&1.tool_name == tool_name))
+
+    matcher =
+      case Keyword.fetch(opts, :gard) do
+        {:ok, gard} -> fn task -> task.tool_name == tool_name and Map.get(task, :gard) == gard end
+        :error -> fn task -> task.tool_name == tool_name end
+      end
+
+    {matching, remaining} = Enum.split_with(queue, matcher)
     state = put_in(state.queues[tenant_id], remaining)
     {:reply, matching, state}
   end

--- a/lib/norns/workers/worker_registry.ex
+++ b/lib/norns/workers/worker_registry.ex
@@ -17,10 +17,11 @@ defmodule Norns.Workers.WorkerRegistry do
 
   # -- Public API --
 
-  @doc "Register a worker with its tool definitions and capabilities."
+  @doc "Register a worker with its tool definitions, capabilities, and optional gard."
   def register_worker(tenant_id, worker_id, channel_pid, tools, opts \\ []) do
     capabilities = Keyword.get(opts, :capabilities, [:tools])
-    GenServer.call(__MODULE__, {:register, tenant_id, worker_id, channel_pid, tools, capabilities})
+    gard = Keyword.get(opts, :gard)
+    GenServer.call(__MODULE__, {:register, tenant_id, worker_id, channel_pid, tools, capabilities, gard})
   end
 
   @doc """
@@ -32,9 +33,20 @@ defmodule Norns.Workers.WorkerRegistry do
     GenServer.cast(__MODULE__, {:unregister, tenant_id, worker_id, channel_pid})
   end
 
-  @doc "Get all tools from connected workers for a tenant, as %Tool{} structs."
-  def available_tools(tenant_id) do
-    GenServer.call(__MODULE__, {:available_tools, tenant_id})
+  @doc """
+  Get all tools from connected workers for a tenant, as %Tool{} structs.
+
+  Gard-filtered with strict equality: without `gard:`, only no-gard workers'
+  tools are returned; with it, only that gard's. The tool list advertised to
+  the LLM must only contain tools dispatch could actually reach.
+  """
+  def available_tools(tenant_id, opts \\ []) do
+    GenServer.call(__MODULE__, {:available_tools, tenant_id, Keyword.get(opts, :gard)})
+  end
+
+  @doc "Kick every worker claiming `gard_id` — used when the gard is destroyed."
+  def kick_gard_workers(tenant_id, gard_id) do
+    GenServer.cast(__MODULE__, {:kick_gard_workers, tenant_id, gard_id})
   end
 
   @doc "Check if any worker with LLM capability is available for a tenant (or :default)."
@@ -92,7 +104,7 @@ defmodule Norns.Workers.WorkerRegistry do
   end
 
   @impl true
-  def handle_call({:register, tenant_id, worker_id, channel_pid, tools, capabilities}, _from, state) do
+  def handle_call({:register, tenant_id, worker_id, channel_pid, tools, capabilities, gard}, _from, state) do
     key = {tenant_id, worker_id}
 
     # A registration under a key that already holds a worker means a reconnect
@@ -109,7 +121,8 @@ defmodule Norns.Workers.WorkerRegistry do
       tools: tools,
       capabilities: capabilities,
       monitor_ref: ref,
-      tenant_id: tenant_id
+      tenant_id: tenant_id,
+      gard: gard
     }
 
     state = put_in(state.workers[key], worker)
@@ -119,7 +132,10 @@ defmodule Norns.Workers.WorkerRegistry do
       |> Enum.map(&tool_name/1)
       |> Enum.reduce(state, fn name, acc ->
         tenant_id
-        |> TaskQueue.flush(name)
+        # Gard-strict flush: a queued gard-bound task must never flush to a
+        # worker in a different gard (or no gard) — that would silently break
+        # the affinity invariant right when the run resumes.
+        |> TaskQueue.flush(name, gard: gard)
         |> Enum.reduce(acc, fn task, pending_state ->
           push_to_worker(channel_pid, {:push_tool_task, task_payload(task)})
           put_in(pending_state.pending[task.task_id], %{from_pid: task.from_pid, tenant_id: tenant_id, type: :tool, worker_key: key})
@@ -141,12 +157,14 @@ defmodule Norns.Workers.WorkerRegistry do
     {:reply, :ok, state}
   end
 
-  def handle_call({:available_tools, tenant_id}, _from, state) do
+  def handle_call({:available_tools, tenant_id, gard}, _from, state) do
     # Only return tools from tenant-specific workers, not the default worker.
     # Default worker tools are in Tools.Registry (local).
+    # Strict gard equality (nil == nil): without it, a gard-bound run would be
+    # offered tools from other gards that dispatch would then fail to reach.
     tools =
       state.workers
-      |> Enum.filter(fn {{tid, _}, _} -> tid == tenant_id end)
+      |> Enum.filter(fn {{tid, _}, w} -> tid == tenant_id and w.gard == gard end)
       |> Enum.flat_map(fn {_, worker} -> worker.tools end)
       |> Enum.map(fn tool_def ->
         %Tool{
@@ -216,8 +234,18 @@ defmodule Norns.Workers.WorkerRegistry do
     agent_id = Keyword.get(opts, :agent_id)
     run_id = Keyword.get(opts, :run_id)
     from_pid = Keyword.get(opts, :from_pid, self())
+    gard = Keyword.get(opts, :gard)
 
-    worker = find_worker(state, tenant_id, fn w -> Process.alive?(w.channel_pid) and Enum.any?(w.tools, &(tool_name(&1) == tool_name)) end)
+    # Strict gard equality (nil == nil, "a" == "a"): no-gard runs never grab a
+    # gard-bound worker (stolen dispatch), gard runs never fall through to a
+    # no-gard worker (filesystem state leakage). The :default-tenant fallback
+    # in find_worker only ever holds no-gard workers, so it can only fire when
+    # gard is nil — a gard-bound run never falls back to a generic worker.
+    worker =
+      find_worker(state, tenant_id, fn w ->
+        Process.alive?(w.channel_pid) and w.gard == gard and
+          Enum.any?(w.tools, &(tool_name(&1) == tool_name))
+      end)
 
     case worker do
       {key, w} ->
@@ -243,7 +271,8 @@ defmodule Norns.Workers.WorkerRegistry do
           input: input,
           from_pid: from_pid,
           agent_id: agent_id,
-          run_id: run_id
+          run_id: run_id,
+          gard: gard
         }
 
         TaskQueue.enqueue(tenant_id, task)
@@ -256,10 +285,11 @@ defmodule Norns.Workers.WorkerRegistry do
     key = {tenant_id, worker_id}
 
     case state.workers[key] do
-      %{channel_pid: stored_pid, monitor_ref: ref}
+      %{channel_pid: stored_pid, monitor_ref: ref} = worker
       when is_nil(channel_pid) or stored_pid == channel_pid ->
         Process.demonitor(ref, [:flush])
         Logger.info("Worker #{worker_id} unregistered from tenant #{tenant_id}")
+        mark_gard_disconnected(worker)
 
         state = %{state | workers: Map.delete(state.workers, key)}
         # Fail this worker's in-flight tasks so agents retry instead of hanging
@@ -297,11 +327,23 @@ defmodule Norns.Workers.WorkerRegistry do
     end
   end
 
+  def handle_cast({:kick_gard_workers, tenant_id, gard_id}, state) do
+    state.workers
+    |> Enum.filter(fn {{tid, _}, w} -> tid == tenant_id and w.gard == gard_id end)
+    |> Enum.each(fn {_, w} -> send(w.channel_pid, :gard_destroyed) end)
+
+    # The channel stops itself, which runs its terminate → unregister → the
+    # normal disconnect cascade (task reclaim, mark_disconnected no-op since
+    # the gard is already destroyed).
+    {:noreply, state}
+  end
+
   @impl true
   def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
     case Enum.find(state.workers, fn {_, w} -> w.monitor_ref == ref end) do
-      {{tenant_id, worker_id} = key, _worker} ->
+      {{tenant_id, worker_id} = key, worker} ->
         Logger.info("Worker #{worker_id} disconnected from tenant #{tenant_id}")
+        mark_gard_disconnected(worker)
         state = %{state | workers: Map.delete(state.workers, key)}
 
         # Fail this worker's in-flight tasks — the agent retry policy re-dispatches
@@ -340,6 +382,28 @@ defmodule Norns.Workers.WorkerRegistry do
 
     %{state | pending: remaining}
   end
+
+  # Both the unregister and DOWN paths can fire on the same disconnect;
+  # Gards.mark_disconnected is idempotent, so calling it from both is safe.
+  #
+  # Isolated in an unlinked task: the registry holds every worker connection,
+  # so a database hiccup must not crash it. The status write is best-effort
+  # bookkeeping — a reconnecting worker re-claims the gard regardless.
+  defp mark_gard_disconnected(%{gard: gard, tenant_id: tenant_id}) when not is_nil(gard) do
+    Task.start(fn ->
+      try do
+        Norns.Gards.mark_disconnected(tenant_id, gard)
+      rescue
+        e -> Logger.warning("failed to mark gard #{gard} disconnected: #{Exception.message(e)}")
+      catch
+        :exit, reason -> Logger.warning("failed to mark gard #{gard} disconnected: #{inspect(reason)}")
+      end
+    end)
+
+    :ok
+  end
+
+  defp mark_gard_disconnected(_worker), do: :ok
 
   defp tool_name(%{"name" => name}), do: name
   defp tool_name(name) when is_binary(name), do: name

--- a/lib/norns_web/channels/agent_channel.ex
+++ b/lib/norns_web/channels/agent_channel.ex
@@ -21,14 +21,29 @@ defmodule NornsWeb.AgentChannel do
   end
 
   @impl true
-  def handle_in("send_message", %{"content" => content}, socket) do
+  def handle_in("send_message", %{"content" => content} = params, socket) do
     tenant_id = socket.assigns.tenant_id
     agent_id = socket.assigns.agent_id
 
-    case Norns.Agents.Registry.send_message(tenant_id, agent_id, content) do
-      {:ok, run_id} -> {:reply, {:ok, %{run_id: run_id}}, socket}
+    with {:ok, gard_id} <- validate_gard(tenant_id, Map.get(params, "gard_id")),
+         {:ok, run_id} <-
+           Norns.Agents.Registry.send_message(tenant_id, agent_id, content, gard_id: gard_id) do
+      {:reply, {:ok, %{run_id: run_id}}, socket}
+    else
+      {:error, :gard_not_found} -> {:reply, {:error, %{reason: "gard not found"}}, socket}
       {:error, :busy} -> {:reply, {:error, %{reason: "agent is busy"}}, socket}
       {:error, reason} -> {:reply, {:error, %{reason: inspect(reason)}}, socket}
+    end
+  end
+
+  # A gard id from another tenant (or a typo) would create a run no worker can
+  # ever serve — reject it up front rather than letting it queue to timeout.
+  defp validate_gard(_tenant_id, nil), do: {:ok, nil}
+
+  defp validate_gard(tenant_id, gard_id) do
+    case Norns.Gards.get_gard(tenant_id, gard_id) do
+      nil -> {:error, :gard_not_found}
+      gard -> {:ok, gard.id}
     end
   end
 

--- a/lib/norns_web/channels/worker_channel.ex
+++ b/lib/norns_web/channels/worker_channel.ex
@@ -2,6 +2,7 @@ defmodule NornsWeb.WorkerChannel do
   use NornsWeb, :channel
 
   require Logger
+  alias Norns.Gards
   alias Norns.Workers.WorkerRegistry
 
   @impl true
@@ -9,10 +10,16 @@ defmodule NornsWeb.WorkerChannel do
     with :ok <- validate_registration(params),
          {:ok, capabilities} <- parse_capabilities(Map.get(params, "capabilities")),
          tenant_id <- socket.assigns.tenant_id,
+         {:ok, gard_id} <- claim_gard(tenant_id, params),
          :ok <- WorkerRegistry.register_worker(tenant_id, params["worker_id"], self(), params["tools"],
-           capabilities: capabilities
+           capabilities: capabilities,
+           gard: gard_id
          ) do
-      socket = assign(socket, :worker_id, params["worker_id"])
+      socket =
+        socket
+        |> assign(:worker_id, params["worker_id"])
+        |> assign(:gard, gard_id)
+
       {:ok, socket}
     else
       {:error, reason} -> {:error, reason}
@@ -25,6 +32,26 @@ defmodule NornsWeb.WorkerChannel do
     {:reply, :ok, socket}
   end
 
+  # Ports arrive on the worker channel rather than a separate HTTP call —
+  # reuses the worker's authentication, and the gard is inferred from the
+  # connection (the worker declared it at join; re-specifying it per port
+  # would be a class of mismatch errors).
+  def handle_in("register_port", %{"internal_port" => _} = params, socket) do
+    case socket.assigns[:gard] do
+      nil ->
+        {:reply, {:error, %{reason: "no gard"}}, socket}
+
+      gard_id ->
+        case Gards.register_port(gard_id, params) do
+          {:ok, port} ->
+            {:reply, {:ok, %{id: port.id, internal_port: port.internal_port, url: port.url}}, socket}
+
+          {:error, changeset} ->
+            {:reply, {:error, %{reason: format_errors(changeset)}}, socket}
+        end
+    end
+  end
+
   @impl true
   def handle_info({:push_tool_task, task}, socket) do
     push(socket, "tool_task", task)
@@ -35,6 +62,14 @@ defmodule NornsWeb.WorkerChannel do
     Logger.info("Pushing llm_task to worker #{socket.assigns[:worker_id]}, task_id=#{task[:task_id]}")
     push(socket, "llm_task", task)
     {:noreply, socket}
+  end
+
+  # The gard this worker claimed was destroyed — close the connection. This
+  # runs terminate → unregister, which fails our in-flight tasks so waiting
+  # agents get an error instead of a timeout.
+  def handle_info(:gard_destroyed, socket) do
+    push(socket, "gard_destroyed", %{})
+    {:stop, :normal, socket}
   end
 
   @impl true
@@ -83,4 +118,40 @@ defmodule NornsWeb.WorkerChannel do
   end
 
   defp parse_capabilities(_other), do: {:error, %{reason: "invalid_registration", code: "invalid_capabilities"}}
+
+  defp claim_gard(_tenant_id, %{"gard" => nil}), do: {:ok, nil}
+
+  defp claim_gard(tenant_id, %{"gard" => gard_id} = params) when not is_nil(gard_id) do
+    case normalize_gard_id(gard_id) do
+      {:ok, gard_id} ->
+        case Gards.claim(tenant_id, gard_id, params["claim_token"]) do
+          :ok -> {:ok, gard_id}
+          {:error, reason} -> {:error, %{reason: to_string(reason), code: "gard_claim_failed"}}
+        end
+
+      :error ->
+        {:error, %{reason: "not_found", code: "gard_claim_failed"}}
+    end
+  end
+
+  defp claim_gard(_tenant_id, _params), do: {:ok, nil}
+
+  defp normalize_gard_id(id) when is_integer(id), do: {:ok, id}
+
+  defp normalize_gard_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {parsed, ""} -> {:ok, parsed}
+      _ -> :error
+    end
+  end
+
+  defp normalize_gard_id(_), do: :error
+
+  defp format_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
 end

--- a/lib/norns_web/controllers/agent_controller.ex
+++ b/lib/norns_web/controllers/agent_controller.ex
@@ -69,7 +69,8 @@ defmodule NornsWeb.AgentController do
     opts = if is_binary(conversation_key) and conversation_key != "", do: [conversation_key: conversation_key], else: []
     opts = if is_map(context), do: Keyword.put(opts, :context, context), else: opts
 
-    with {:ok, agent} <- fetch_agent(agent_id, tenant.id) do
+    with {:ok, agent} <- fetch_agent(agent_id, tenant.id),
+         {:ok, opts} <- put_gard_opt(opts, tenant.id, Map.get(params, "gard_id")) do
       case Registry.send_message(tenant.id, agent.id, content, opts) do
         {:ok, run_id} -> conn |> put_status(202) |> json(%{status: "accepted", run_id: run_id})
         {:error, :busy} -> conn |> put_status(409) |> json(%{error: "agent is busy"})
@@ -80,6 +81,17 @@ defmodule NornsWeb.AgentController do
 
   def send_message(conn, %{"agent_id" => _}) do
     conn |> put_status(422) |> json(%{error: "missing required field: content"})
+  end
+
+  # A gard id from another tenant (or a typo) would create a run no worker can
+  # ever serve — reject it as not-found rather than letting it queue to timeout.
+  defp put_gard_opt(opts, _tenant_id, nil), do: {:ok, opts}
+
+  defp put_gard_opt(opts, tenant_id, gard_id) do
+    case Norns.Gards.get_gard(tenant_id, gard_id) do
+      nil -> {:error, :not_found}
+      gard -> {:ok, Keyword.put(opts, :gard_id, gard.id)}
+    end
   end
 
   def runs(conn, %{"agent_id" => agent_id}) do

--- a/lib/norns_web/controllers/gard_controller.ex
+++ b/lib/norns_web/controllers/gard_controller.ex
@@ -1,0 +1,112 @@
+defmodule NornsWeb.GardController do
+  use NornsWeb, :controller
+
+  alias Norns.Gards
+
+  def index(conn, _params) do
+    tenant = conn.assigns.current_tenant
+    gards = Gards.list_gards(tenant.id)
+    json(conn, %{data: Enum.map(gards, &NornsWeb.JSON.gard/1)})
+  end
+
+  def create(conn, params) do
+    tenant = conn.assigns.current_tenant
+    attrs = Map.put(params, "tenant_id", tenant.id)
+
+    case Gards.create_gard(attrs) do
+      {:ok, gard} ->
+        # The claim token is returned exactly once, here — it's the secret the
+        # provisioner hands to the worker. List/show never include it.
+        data = gard |> NornsWeb.JSON.gard() |> Map.put(:claim_token, gard.claim_token)
+        conn |> put_status(201) |> json(%{data: data})
+
+      {:error, changeset} ->
+        conn |> put_status(422) |> json(%{error: format_errors(changeset)})
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    tenant = conn.assigns.current_tenant
+
+    with {:ok, gard} <- fetch_gard(tenant.id, id) do
+      data =
+        gard
+        |> NornsWeb.JSON.gard()
+        |> Map.put(:ports, Enum.map(Gards.list_ports(gard.id), &NornsWeb.JSON.gard_port/1))
+
+      json(conn, %{data: data})
+    end
+  end
+
+  def update(conn, %{"id" => id} = params) do
+    tenant = conn.assigns.current_tenant
+
+    with {:ok, gard} <- fetch_gard(tenant.id, id) do
+      attrs = Map.drop(params, ["id", "tenant_id", "status", "claim_token"])
+
+      case Gards.update_gard(gard, attrs) do
+        {:ok, gard} ->
+          json(conn, %{data: NornsWeb.JSON.gard(gard)})
+
+        {:error, changeset} ->
+          conn |> put_status(422) |> json(%{error: format_errors(changeset)})
+      end
+    end
+  end
+
+  def delete(conn, %{"id" => id} = params) do
+    tenant = conn.assigns.current_tenant
+    force = Map.get(params, "force") in [true, "true"]
+
+    with {:ok, gard} <- fetch_gard(tenant.id, id) do
+      case Gards.destroy(tenant.id, gard.id, force: force) do
+        :ok ->
+          send_resp(conn, 204, "")
+
+        {:error, :active_run} ->
+          conn
+          |> put_status(409)
+          |> json(%{error: "gard has an active run — pass force=true to destroy anyway"})
+
+        {:error, _} ->
+          conn |> put_status(404) |> json(%{error: "not found"})
+      end
+    end
+  end
+
+  def ports(conn, %{"gard_id" => id}) do
+    tenant = conn.assigns.current_tenant
+
+    with {:ok, gard} <- fetch_gard(tenant.id, id) do
+      json(conn, %{data: Enum.map(Gards.list_ports(gard.id), &NornsWeb.JSON.gard_port/1)})
+    end
+  end
+
+  defp fetch_gard(tenant_id, id) do
+    case Gards.get_gard(tenant_id, id) do
+      nil -> {:error, :not_found}
+      gard -> {:ok, gard}
+    end
+  end
+
+  defp format_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
+
+  # Override action/2 to handle {:error, :not_found} from with clauses
+  def action(conn, _) do
+    args = [conn, conn.params]
+
+    case apply(__MODULE__, action_name(conn), args) do
+      {:error, :not_found} ->
+        conn |> put_status(404) |> json(%{error: "not found"})
+
+      conn ->
+        conn
+    end
+  end
+end

--- a/lib/norns_web/json.ex
+++ b/lib/norns_web/json.ex
@@ -24,6 +24,7 @@ defmodule NornsWeb.JSON do
       conversation_id: run.conversation_id,
       parent_run_id: run.parent_run_id,
       depth: run.depth,
+      gard_id: run.gard_id,
       status: run.status,
       trigger_type: run.trigger_type,
       input: run.input,
@@ -35,6 +36,29 @@ defmodule NornsWeb.JSON do
       output_tokens: run.output_tokens || 0,
       inserted_at: run.inserted_at,
       updated_at: run.updated_at
+    }
+  end
+
+  # Never includes the claim token — that's returned once, on create.
+  def gard(gard) do
+    %{
+      id: gard.id,
+      name: gard.name,
+      status: gard.status,
+      template: gard.template,
+      metadata: gard.metadata || %{},
+      inserted_at: gard.inserted_at,
+      updated_at: gard.updated_at
+    }
+  end
+
+  def gard_port(port) do
+    %{
+      id: port.id,
+      internal_port: port.internal_port,
+      url: port.url,
+      name: port.name,
+      protocol: port.protocol
     }
   end
 

--- a/lib/norns_web/router.ex
+++ b/lib/norns_web/router.ex
@@ -55,6 +55,10 @@ defmodule NornsWeb.Router do
       post "/fire", TriggerController, :fire
     end
 
+    resources "/gards", GardController, only: [:create, :index, :show, :update, :delete] do
+      get "/ports", GardController, :ports
+    end
+
     get "/runs", RunController, :index
     get "/runs/:id", RunController, :show
     get "/runs/:id/events", RunController, :events

--- a/priv/repo/migrations/20260810000200_create_gards.exs
+++ b/priv/repo/migrations/20260810000200_create_gards.exs
@@ -1,0 +1,35 @@
+defmodule Norns.Repo.Migrations.CreateGards do
+  use Ecto.Migration
+
+  def change do
+    create table(:gards) do
+      add :tenant_id, references(:tenants), null: false
+      add :name, :string
+      add :status, :string, null: false, default: "pending"
+      add :template, :string
+      add :claim_token, :string, null: false
+      add :metadata, :map, default: %{}, null: false
+
+      timestamps()
+    end
+
+    create index(:gards, [:tenant_id])
+    create index(:gards, [:tenant_id, :status])
+
+    create table(:gard_ports) do
+      add :gard_id, references(:gards, on_delete: :delete_all), null: false
+      add :internal_port, :integer, null: false
+      add :url, :string
+      add :name, :string
+      add :protocol, :string, default: "http", null: false
+
+      timestamps()
+    end
+
+    create index(:gard_ports, [:gard_id])
+
+    alter table(:runs) do
+      add :gard_id, references(:gards), null: true
+    end
+  end
+end

--- a/test/norns/agents/process_gard_test.exs
+++ b/test/norns/agents/process_gard_test.exs
@@ -1,0 +1,171 @@
+defmodule Norns.Agents.ProcessGardTest do
+  use Norns.DataCase, async: false
+
+  alias Norns.{Gards, Runs}
+  alias Norns.Agents.Process, as: AgentProcess
+  alias Norns.Agents.Registry, as: AgentRegistry
+  alias Norns.LLM.Fake
+  alias Norns.Runtime.Events
+  alias Norns.Tools.Tool
+
+  setup do
+    tenant = create_tenant()
+    agent = create_agent(tenant)
+    {:ok, gard} = Gards.create_gard(%{tenant_id: tenant.id, name: "workspace"})
+    :ok = Gards.claim(tenant.id, gard.id, gard.claim_token)
+
+    %{tenant: tenant, agent: agent, gard: gard}
+  end
+
+  defp tool(name, result) do
+    %Tool{
+      name: name,
+      description: name,
+      input_schema: %{},
+      handler: fn _ -> {:ok, result} end
+    }
+  end
+
+  defp start_worker(tenant, opts) do
+    {:ok, pid} = Norns.TestWorker.start_link(Keyword.merge([tenant: tenant.id, name: nil, capabilities: [:tools]], opts))
+
+    on_exit(fn ->
+      if Process.alive?(pid), do: GenServer.stop(pid)
+    end)
+
+    pid
+  end
+
+  defp wait_for(event, timeout \\ 5000) do
+    receive do
+      {^event, payload} -> payload
+    after
+      timeout -> flunk("Did not receive #{event} within #{timeout}ms")
+    end
+  end
+
+  test "a gard-bound run sees and uses only its gard's tools", %{tenant: tenant, agent: agent, gard: gard} do
+    start_worker(tenant, worker_id: "gard-worker", gard: gard.id, tools: [tool("read_file", "gard file contents")])
+    start_worker(tenant, worker_id: "plain-worker", tools: [tool("plain_tool", "plain result")])
+
+    Fake.set_responses([
+      %{
+        content: [
+          %{"type" => "tool_use", "id" => "call_1", "name" => "read_file", "input" => %{"path" => "x"}}
+        ],
+        stop_reason: "tool_use"
+      },
+      %{content: [%{"type" => "text", "text" => "done"}], stop_reason: "end_turn"}
+    ])
+
+    Phoenix.PubSub.subscribe(Norns.PubSub, "agent:#{agent.id}")
+
+    {:ok, run_id} =
+      AgentRegistry.send_message(tenant.id, agent.id, "read the file", gard_id: gard.id)
+
+    wait_for(:completed)
+
+    run = Runs.get_run!(run_id)
+    assert run.gard_id == gard.id
+
+    events = Runs.list_events(run.id)
+
+    request = Enum.find(events, &(&1.event_type == "llm_request"))
+    assert "read_file" in request.payload["tools"]
+    refute "plain_tool" in request.payload["tools"]
+
+    result = Enum.find(events, &(&1.event_type == "tool_result"))
+    assert result.payload["content"] == "gard file contents"
+  end
+
+  test "a no-gard run sees only no-gard tools", %{tenant: tenant, agent: agent, gard: gard} do
+    start_worker(tenant, worker_id: "gard-worker", gard: gard.id, tools: [tool("read_file", "x")])
+    start_worker(tenant, worker_id: "plain-worker", tools: [tool("plain_tool", "plain result")])
+
+    Fake.set_responses([
+      %{content: [%{"type" => "text", "text" => "done"}], stop_reason: "end_turn"}
+    ])
+
+    Phoenix.PubSub.subscribe(Norns.PubSub, "agent:#{agent.id}")
+    {:ok, run_id} = AgentRegistry.send_message(tenant.id, agent.id, "hello")
+    wait_for(:completed)
+
+    request = Enum.find(Runs.list_events(run_id), &(&1.event_type == "llm_request"))
+    assert "plain_tool" in request.payload["tools"]
+    refute "read_file" in request.payload["tools"]
+  end
+
+  test "a resumed run keeps its gard affinity", %{tenant: tenant, agent: agent, gard: gard} do
+    start_worker(tenant, worker_id: "gard-worker", gard: gard.id, tools: [tool("read_file", "x")])
+
+    {:ok, run} =
+      Runs.create_run(%{
+        tenant_id: tenant.id,
+        agent_id: agent.id,
+        trigger_type: "message",
+        status: "running",
+        input: %{"user_message" => "carry on"},
+        gard_id: gard.id
+      })
+
+    {:ok, started} = Events.run_started()
+    {:ok, _} = Runs.append_event(run, started)
+
+    Fake.set_responses([
+      %{content: [%{"type" => "text", "text" => "resumed and done"}], stop_reason: "end_turn"}
+    ])
+
+    Phoenix.PubSub.subscribe(Norns.PubSub, "agent:#{agent.id}")
+
+    {:ok, _pid} =
+      AgentProcess.start_link(
+        agent_id: agent.id,
+        tenant_id: tenant.id,
+        resume_run_id: run.id,
+        conversation_key: "resume-test"
+      )
+
+    wait_for(:completed)
+
+    request = Enum.find(Runs.list_events(run.id), &(&1.event_type == "llm_request"))
+    # The resumed run still advertises its gard's tools — affinity survived.
+    assert "read_file" in request.payload["tools"]
+  end
+
+  test "a child launched from a gard-bound run inherits the gard", %{tenant: tenant, agent: agent, gard: gard} do
+    child_agent = create_agent(tenant, %{name: "child-#{System.unique_integer([:positive])}"})
+
+    Fake.set_responses([
+      # Parent launches the child
+      %{
+        content: [
+          %{
+            "type" => "tool_use",
+            "id" => "call_launch",
+            "name" => "launch_agent",
+            "input" => %{"agent_name" => child_agent.name, "message" => "do the subtask"}
+          }
+        ],
+        stop_reason: "tool_use"
+      },
+      # Child completes immediately
+      %{content: [%{"type" => "text", "text" => "child done"}], stop_reason: "end_turn"},
+      # Parent wraps up
+      %{content: [%{"type" => "text", "text" => "parent done"}], stop_reason: "end_turn"}
+    ])
+
+    Phoenix.PubSub.subscribe(Norns.PubSub, "agent:#{agent.id}")
+
+    {:ok, _run_id} =
+      AgentRegistry.send_message(tenant.id, agent.id, "delegate this", gard_id: gard.id)
+
+    wait_for(:completed)
+
+    child_run =
+      Runs.list_runs(child_agent.id)
+      |> List.first()
+
+    assert child_run != nil
+    assert child_run.gard_id == gard.id
+  end
+end

--- a/test/norns/gards_test.exs
+++ b/test/norns/gards_test.exs
@@ -1,0 +1,193 @@
+defmodule Norns.GardsTest do
+  use Norns.DataCase, async: false
+
+  alias Norns.{Gards, Runs}
+  alias Norns.Tools.Idempotency
+
+  setup do
+    %{tenant: create_tenant()}
+  end
+
+  defp create_gard(tenant, attrs \\ %{}) do
+    {:ok, gard} = Gards.create_gard(Map.merge(%{tenant_id: tenant.id, name: "test-gard"}, attrs))
+    gard
+  end
+
+  describe "create_gard/1" do
+    test "generates a server-side claim token and starts pending", %{tenant: tenant} do
+      gard = create_gard(tenant)
+
+      assert gard.status == "pending"
+      assert is_binary(gard.claim_token)
+      # 32 bytes, url-base64, no padding
+      assert String.length(gard.claim_token) == 43
+    end
+  end
+
+  describe "claim/3" do
+    test "a valid token claims a pending gard", %{tenant: tenant} do
+      gard = create_gard(tenant)
+
+      assert Gards.claim(tenant.id, gard.id, gard.claim_token) == :ok
+      assert Gards.get_gard(tenant.id, gard.id).status == "ready"
+    end
+
+    test "only one of two claimants wins", %{tenant: tenant} do
+      gard = create_gard(tenant)
+
+      assert Gards.claim(tenant.id, gard.id, gard.claim_token) == :ok
+      assert Gards.claim(tenant.id, gard.id, gard.claim_token) == {:error, :already_claimed}
+    end
+
+    test "a wrong token is rejected", %{tenant: tenant} do
+      gard = create_gard(tenant)
+      assert Gards.claim(tenant.id, gard.id, "wrong") == {:error, :invalid_claim_token}
+      assert Gards.claim(tenant.id, gard.id, nil) == {:error, :invalid_claim_token}
+    end
+
+    test "claims are tenant-scoped", %{tenant: tenant} do
+      other = create_tenant()
+      gard = create_gard(tenant)
+
+      assert Gards.claim(other.id, gard.id, gard.claim_token) == {:error, :not_found}
+    end
+
+    test "a destroyed gard cannot be claimed", %{tenant: tenant} do
+      gard = create_gard(tenant)
+      :ok = Gards.destroy(tenant.id, gard.id)
+
+      assert Gards.claim(tenant.id, gard.id, gard.claim_token) == {:error, :gard_destroyed}
+    end
+
+    test "a disconnected gard can be reclaimed", %{tenant: tenant} do
+      gard = create_gard(tenant)
+      :ok = Gards.claim(tenant.id, gard.id, gard.claim_token)
+      :ok = Gards.mark_disconnected(tenant.id, gard.id)
+
+      assert Gards.claim(tenant.id, gard.id, gard.claim_token) == :ok
+      assert Gards.get_gard(tenant.id, gard.id).status == "ready"
+    end
+  end
+
+  describe "mark_disconnected/2" do
+    test "is idempotent — both disconnect paths can fire", %{tenant: tenant} do
+      gard = create_gard(tenant)
+      :ok = Gards.claim(tenant.id, gard.id, gard.claim_token)
+
+      assert Gards.mark_disconnected(tenant.id, gard.id) == :ok
+      assert Gards.mark_disconnected(tenant.id, gard.id) == :ok
+      assert Gards.get_gard(tenant.id, gard.id).status == "disconnected"
+    end
+
+    test "does not resurrect a destroyed gard", %{tenant: tenant} do
+      gard = create_gard(tenant)
+      :ok = Gards.destroy(tenant.id, gard.id)
+      :ok = Gards.mark_disconnected(tenant.id, gard.id)
+
+      assert Gards.get_gard(tenant.id, gard.id).status == "destroyed"
+    end
+  end
+
+  describe "destroy/3" do
+    test "soft-deletes and removes ports; the row survives for run FKs", %{tenant: tenant} do
+      gard = create_gard(tenant)
+      {:ok, _} = Gards.register_port(gard.id, %{"internal_port" => 3000, "url" => "http://localhost:3000"})
+
+      agent = create_agent(tenant)
+
+      {:ok, run} =
+        Runs.create_run(%{
+          tenant_id: tenant.id,
+          agent_id: agent.id,
+          trigger_type: "message",
+          status: "completed",
+          gard_id: gard.id
+        })
+
+      assert Gards.destroy(tenant.id, gard.id) == :ok
+      assert Gards.get_gard(tenant.id, gard.id).status == "destroyed"
+      assert Gards.list_ports(gard.id) == []
+      assert Runs.get_run!(run.id).gard_id == gard.id
+    end
+
+    test "refuses while a run is active, unless forced", %{tenant: tenant} do
+      gard = create_gard(tenant)
+      agent = create_agent(tenant)
+
+      {:ok, _run} =
+        Runs.create_run(%{
+          tenant_id: tenant.id,
+          agent_id: agent.id,
+          trigger_type: "message",
+          status: "running",
+          gard_id: gard.id
+        })
+
+      assert Gards.destroy(tenant.id, gard.id) == {:error, :active_run}
+      assert Gards.destroy(tenant.id, gard.id, force: true) == :ok
+    end
+  end
+
+  describe "ports" do
+    test "registers and lists ports with valid schemes", %{tenant: tenant} do
+      gard = create_gard(tenant)
+
+      {:ok, port} =
+        Gards.register_port(gard.id, %{
+          "internal_port" => 3000,
+          "url" => "https://abc-3000.tunnel.dev",
+          "name" => "react"
+        })
+
+      assert port.protocol == "http"
+      assert [%{internal_port: 3000}] = Gards.list_ports(gard.id)
+    end
+
+    test "rejects dangerous URL schemes", %{tenant: tenant} do
+      gard = create_gard(tenant)
+
+      assert {:error, changeset} =
+               Gards.register_port(gard.id, %{
+                 "internal_port" => 3000,
+                 "url" => "javascript:alert(1)"
+               })
+
+      assert Keyword.has_key?(changeset.errors, :url)
+    end
+
+    test "rejects out-of-range ports", %{tenant: tenant} do
+      gard = create_gard(tenant)
+
+      assert {:error, _} = Gards.register_port(gard.id, %{"internal_port" => 0})
+      assert {:error, _} = Gards.register_port(gard.id, %{"internal_port" => 70_000})
+    end
+  end
+
+  describe "idempotency keys" do
+    test "the gard rides in the key; no-gard keys keep the historical shape" do
+      assert Idempotency.key(1, 2, "tc_1", "write_file") ==
+               "run:1:step:2:tool:tc_1:name:write_file"
+
+      assert Idempotency.key(1, 2, "tc_1", "write_file", 7) ==
+               "run:1:step:2:tool:tc_1:name:write_file:gard:7"
+    end
+
+    test "context derives the gard from the run" do
+      tool = %Norns.Tools.Tool{
+        name: "write_file",
+        description: "",
+        input_schema: %{},
+        handler: fn _ -> {:ok, ""} end,
+        side_effect?: true
+      }
+
+      tc = %{"id" => "tc_1", "name" => "write_file", "arguments" => %{}}
+
+      ctx = Idempotency.context(%{id: 1, gard_id: 7}, 2, tc, tool)
+      assert ctx.idempotency_key == "run:1:step:2:tool:tc_1:name:write_file:gard:7"
+
+      ctx = Idempotency.context(%{id: 1, gard_id: nil}, 2, tc, tool)
+      assert ctx.idempotency_key == "run:1:step:2:tool:tc_1:name:write_file"
+    end
+  end
+end

--- a/test/norns/workers/worker_registry_gard_test.exs
+++ b/test/norns/workers/worker_registry_gard_test.exs
@@ -1,0 +1,110 @@
+defmodule Norns.Workers.WorkerRegistryGardTest do
+  use Norns.DataCase, async: false
+
+  alias Norns.Workers.WorkerRegistry
+
+  # Unique tenant ids per test keep the shared registry from cross-talking.
+  defp tenant_id, do: System.unique_integer([:positive]) + 100_000
+
+  defp tool_def(name), do: %{"name" => name, "description" => name, "input_schema" => %{}}
+
+  describe "available_tools/2 gard filter" do
+    test "strict equality: no-gard callers see no-gard tools, gard callers see their gard's" do
+      tid = tenant_id()
+      :ok = WorkerRegistry.register_worker(tid, "plain", self(), [tool_def("plain_tool")])
+      :ok = WorkerRegistry.register_worker(tid, "garded", self(), [tool_def("gard_tool")], gard: 42)
+
+      assert [%{name: "plain_tool"}] = WorkerRegistry.available_tools(tid)
+      assert [%{name: "gard_tool"}] = WorkerRegistry.available_tools(tid, gard: 42)
+      assert [] = WorkerRegistry.available_tools(tid, gard: 99)
+
+      WorkerRegistry.unregister_worker(tid, "plain")
+      WorkerRegistry.unregister_worker(tid, "garded")
+    end
+  end
+
+  describe "dispatch_task/4 gard strictness" do
+    test "a gard-bound task never reaches a no-gard worker (it queues instead)" do
+      tid = tenant_id()
+      :ok = WorkerRegistry.register_worker(tid, "plain", self(), [tool_def("shared_tool")])
+
+      {:ok, _} = WorkerRegistry.dispatch_task(tid, "shared_tool", %{}, from_pid: self(), gard: 42)
+      refute_receive {:push_tool_task, _}, 100
+
+      WorkerRegistry.unregister_worker(tid, "plain")
+    end
+
+    test "a no-gard task never reaches a gard-bound worker (no stolen dispatch)" do
+      tid = tenant_id()
+      :ok = WorkerRegistry.register_worker(tid, "garded", self(), [tool_def("shared_tool")], gard: 42)
+
+      {:ok, _} = WorkerRegistry.dispatch_task(tid, "shared_tool", %{}, from_pid: self())
+      refute_receive {:push_tool_task, _}, 100
+
+      WorkerRegistry.unregister_worker(tid, "garded")
+    end
+
+    test "a gard-bound task reaches the matching gard worker" do
+      tid = tenant_id()
+      :ok = WorkerRegistry.register_worker(tid, "garded", self(), [tool_def("shared_tool")], gard: 42)
+
+      {:ok, task_id} = WorkerRegistry.dispatch_task(tid, "shared_tool", %{}, from_pid: self(), gard: 42)
+      assert_receive {:push_tool_task, %{task_id: ^task_id}}, 500
+
+      WorkerRegistry.unregister_worker(tid, "garded")
+    end
+  end
+
+  describe "queued task flush is gard-aware" do
+    test "a queued gard task waits for a matching-gard worker" do
+      tid = tenant_id()
+
+      # No worker yet — both tasks queue.
+      {:ok, gard_task} = WorkerRegistry.dispatch_task(tid, "late_tool", %{}, from_pid: self(), gard: 42)
+      {:ok, plain_task} = WorkerRegistry.dispatch_task(tid, "late_tool", %{}, from_pid: self())
+
+      # A no-gard worker connects: only the no-gard task flushes to it.
+      :ok = WorkerRegistry.register_worker(tid, "plain", self(), [tool_def("late_tool")])
+      assert_receive {:push_tool_task, %{task_id: ^plain_task}}, 500
+      refute_receive {:push_tool_task, _}, 100
+
+      # The gard worker connects: the gard task flushes to it.
+      :ok = WorkerRegistry.register_worker(tid, "garded", self(), [tool_def("late_tool")], gard: 42)
+      assert_receive {:push_tool_task, %{task_id: ^gard_task}}, 500
+
+      WorkerRegistry.unregister_worker(tid, "plain")
+      WorkerRegistry.unregister_worker(tid, "garded")
+    end
+  end
+
+  describe "LLM dispatch is not gard-filtered" do
+    test "an LLM task reaches a gard-bound LLM worker" do
+      tid = tenant_id()
+
+      :ok =
+        WorkerRegistry.register_worker(tid, "garded-llm", self(), [],
+          capabilities: [:llm],
+          gard: 42
+        )
+
+      {:ok, task_id} = WorkerRegistry.dispatch_llm_task(tid, %{model: "m"}, from_pid: self())
+      assert_receive {:llm_task, %{task_id: ^task_id}}, 500
+
+      WorkerRegistry.unregister_worker(tid, "garded-llm")
+    end
+  end
+
+  describe "gard status follows the worker connection" do
+    test "unregistering a gard worker marks the gard disconnected" do
+      tenant = create_tenant()
+      {:ok, gard} = Norns.Gards.create_gard(%{tenant_id: tenant.id, name: "g"})
+      :ok = Norns.Gards.claim(tenant.id, gard.id, gard.claim_token)
+
+      :ok = WorkerRegistry.register_worker(tenant.id, "gw", self(), [], gard: gard.id)
+      WorkerRegistry.unregister_worker(tenant.id, "gw")
+      Process.sleep(100)
+
+      assert Norns.Gards.get_gard(tenant.id, gard.id).status == "disconnected"
+    end
+  end
+end

--- a/test/support/test_worker.ex
+++ b/test/support/test_worker.ex
@@ -12,12 +12,19 @@ defmodule Norns.TestWorker do
   alias Norns.Workers.WorkerRegistry
 
   def start_link(opts \\ []) do
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> GenServer.start_link(__MODULE__, opts)
+      name -> GenServer.start_link(__MODULE__, opts, name: name)
+    end
   end
 
   @impl true
   def init(opts) do
     tools = Keyword.get(opts, :tools, [])
+    tenant = Keyword.get(opts, :tenant, :default)
+    worker_id = Keyword.get(opts, :worker_id, "test-worker")
+    capabilities = Keyword.get(opts, :capabilities, [:llm, :tools])
+    gard = Keyword.get(opts, :gard)
 
     tool_defs =
       Enum.map(tools, fn tool ->
@@ -30,11 +37,12 @@ defmodule Norns.TestWorker do
       end)
 
     WorkerRegistry.register_worker(
-      :default,
-      "test-worker",
+      tenant,
+      worker_id,
       self(),
       tool_defs,
-      capabilities: [:llm, :tools]
+      capabilities: capabilities,
+      gard: gard
     )
 
     {:ok, %{tools: tools}}


### PR DESCRIPTION
Roadmap step 3, per `docs/gards.md` (v7). A gard is a bounded execution context — filesystem, container, VM — where exactly one worker operates. Norns tracks gards and routes tool dispatch to them; it never provisions infrastructure. Fully opt-in: no-gard runs and workers behave exactly as before.

## What

- **Schema**: `gards` (status `pending → ready → disconnected → destroyed`, server-generated 256-bit claim token, metadata) + `gard_ports` (URL scheme restricted to http/https/tcp — no `javascript:` in dashboard links) + nullable `runs.gard_id`. Gards are soft-delete only, keeping the runs FK valid forever.
- **`Norns.Gards`**: atomic conditional-UPDATE claim (of N simultaneous claimants exactly one wins; classified errors for the losers), idempotent `mark_disconnected` (both disconnect paths can fire), `destroy` with active-run guard (`force: true` to override) that kicks the connected worker through the normal disconnect cascade.
- **Dispatch is gard-strict end to end** (the doc's concurrency invariants, all implemented):
  - `find_worker`: strict equality — no-gard runs never grab gard workers (stolen dispatch), gard runs never leak to no-gard workers (filesystem state leakage). The `:default`-tenant fallback can only fire for no-gard runs.
  - `available_tools`: gard-filtered, so the LLM is never offered a tool dispatch can't reach.
  - TaskQueue flush matches `{tenant, tool, gard}` — a queued gard task can't flush to the wrong worker.
  - LLM dispatch deliberately NOT filtered: inference has no filesystem affinity.
- **Per-run binding**: `send_message(..., gard_id:)` through Registry/channel/REST (with tenant-scoped validation — a foreign gard id 404s instead of queueing to timeout). Children inherit the parent's gard unless the `launch_agent` call names one. **Resume restores affinity from the run row** — a recovered run keeps dispatching into its gard.
- **Idempotency keys include the gard**: same `(tool, args)` in two gards is two operations. No-gard keys keep the historical shape, so runs from before this change replay correctly.
- **Registry resilience**: the disconnect status write runs in an isolated task — a DB hiccup must not crash the GenServer holding every worker connection.
- **API**: gard CRUD (claim token returned exactly once, on create — list/show never include it) + ports; workers register ports as channel pushes with the gard inferred from the socket.

## Tests

27 new tests across three files: claim atomicity/classification/tenant scoping, disconnect idempotency, destroy guards, port scheme validation, dispatch strictness in all four directions, gard-aware queue flush, LLM non-filtering, gard status following the connection, and process-level integration — gard-bound runs see and use only their gard's tools, no-gard runs see only no-gard tools, resumed runs keep affinity, children inherit the gard. Full suite: 270 tests, 0 failures, `--warnings-as-errors` and credo clean.

## Not in this PR (tracked as Phase 1 remainder)

`nornsctl gard` commands, the `/gards` dashboard LiveView, Python SDK `gard`/`claim_token` support. The tool catalog endpoint intentionally keeps showing the no-gard surface (what a default run can reach).