### PR TITLE
Gards dashboard page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,8 @@ nornsctl runs events <id> [--json]            # Full event log for a run
 nornsctl runs retry <id>                      # Retry a failed run
 nornsctl triggers list [--agent <id>]         # List cron triggers
 nornsctl triggers fire <id>                   # Fire a trigger now, outside its schedule
+nornsctl gards list                           # List gards (worker execution contexts)
+nornsctl gards create [--name N]              # Create a gard, prints its claim token once
 nornsctl conversations list <agent_id>        # List conversations
 nornsctl conversations show <agent_id> <key>  # Conversation details
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ nornsctl runs events <id> [--json]            # Full event log for a run
 nornsctl runs retry <id>                      # Retry a failed run
 nornsctl triggers list [--agent <id>]         # List cron triggers
 nornsctl triggers fire <id>                   # Fire a trigger now, outside its schedule
+nornsctl gards list                           # List gards (worker execution contexts)
+nornsctl gards create [--name N]              # Create a gard, prints its claim token once
 nornsctl conversations list <agent_id>        # List conversations
 nornsctl conversations show <agent_id> <key>  # Conversation details
 ```

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -120,13 +120,13 @@ Last updated: 2026-08-10
 - Runs started by a trigger carry `trigger_type: "schedule"`. Cron expressions validated with `Oban.Cron.Expression` at write time.
 - Default is task mode (fresh conversation per firing); setting `conversation_key` opts into shared history across firings.
 
-### Gards Phase 1 (core)
+### Gards Phase 1
 - `Norns.Gards` — gard registry with server-generated 256-bit claim tokens, atomic claim (one winner among simultaneous claimants), idempotent disconnect marking, soft-delete destroy with active-run guard and worker kick.
 - Dispatch is gard-strict end to end: `find_worker` strict equality, `available_tools` gard-filtered, TaskQueue flush matches `{tenant, tool, gard}`. LLM dispatch deliberately unfiltered (no filesystem affinity).
 - Gard binds per-run (`send_message gard_id:`), children inherit the parent's gard, resume restores affinity from the run row, idempotency keys include the gard (no-gard keys keep the historical shape, so pre-gard runs replay correctly).
 - The disconnect status write runs in an isolated task — a database hiccup must not crash the registry that holds every worker connection.
 - REST: gard CRUD (claim token returned exactly once, on create) + ports; workers register ports over their channel, gard inferred from the connection.
-- Remaining Phase 1 surface: `nornsctl gard`, dashboard page, Python SDK support.
+- Full surface: `nornsctl gards` commands, `/gards` dashboard page, Python SDK `gard`/`claim_token` on `run()` + `register_port` (fatal vs retryable claim failures distinguished — `already_claimed` retries because a quick reconnect can race the disconnect bookkeeping; bad token/destroyed gard raise instead of spinning).
 
 ### Sub-agent crash recovery
 - A resumed parent reattaches to its in-flight child by run id instead of relaunching it — a pending `launch_agent` is a reference to work already underway, not a request.

--- a/docs/gards.md
+++ b/docs/gards.md
@@ -1,6 +1,6 @@
 # Norns Gards — Design Document
 
-## Status: v7 — Phase 1 core shipped 2026-08-10 (registry, claims, strict dispatch, per-run binding, API; `nornsctl`/dashboard/Python SDK still open). The provisioner is on the critical path per the fork decision in `decision-log.md`, and its first product is managed connectors (§ The cloud boundary)
+## Status: v8 — Phase 1 shipped in full 2026-08-10 (registry, claims, strict dispatch, per-run binding, API, `nornsctl gards`, dashboard, Python SDK). Next: Phase 2 provisioner, connector workload first — see `decision-log.md` § The cloud boundary
 
 ## Summary
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,7 +55,7 @@ builder later composes against.
 flowchart TB
     A["1 — Per-agent tool selection ✓<br/>ToolPolicy on AgentDef — shipped 2026-08-10"]
     B["2 — Cron triggers ✓<br/>triggers table · Oban · API — shipped 2026-08-10"]
-    C["3 — Gards Phase 1 ✓<br/>registry + dispatch filter — core shipped 2026-08-10"]
+    C["3 — Gards Phase 1 ✓<br/>registry + dispatch filter — shipped 2026-08-10"]
     D["4 — Fabricate toolkit<br/>templates · scaffold AGENTS.md · nornsctl --wait"]
     E["5 — Inbound webhooks<br/>POST /api/v1/hooks/:token · signature verification"]
     F["6 — Provisioner<br/>separate repo · managed connectors first, then coding-agent gards"]
@@ -81,16 +81,18 @@ the system of record — composed agents have no repo for config to live in.
 `nornsctl triggers` (list/show/create/update/enable/disable/delete/fire)
 shipped in the nornsctl repo the same day.
 
-### 3. Gards Phase 1 — core shipped (2026-08-10)
+### 3. Gards Phase 1 — done (2026-08-10)
 
 Registry + dispatch filter, per `gards.md`: `gards`/`gard_ports` tables,
 atomic claim tokens, strict-equality dispatch (no-gard runs never touch gard
 workers and vice versa), gard-filtered tool advertisement, gard-aware
 TaskQueue flush, per-run binding with child inheritance and resume-safe
 affinity, gard-scoped idempotency keys, REST CRUD + worker-channel port
-registration. Remaining from the Phase 1 list: `nornsctl gard` commands,
-the `/gards` dashboard page, and Python SDK `gard`/`claim_token` support.
-Secrets injection stays a named provisioner (Phase 2) requirement.
+registration. The full surface shipped with it: `nornsctl gards`
+(create/list/inspect/ports/destroy), the `/gards` dashboard page, and Python
+SDK support (`norns.run(agent, gard=, claim_token=)` + `register_port`) —
+verified end to end against a live worker. Secrets injection stays a named
+provisioner (Phase 2) requirement.
 
 ### 4. Fabricate toolkit
 

--- a/lib/norns/workers/worker_registry.ex
+++ b/lib/norns/workers/worker_registry.ex
@@ -185,7 +185,7 @@ defmodule Norns.Workers.WorkerRegistry do
       state.workers
       |> Enum.filter(fn {{tid, _}, w} -> tid == tenant_id and Process.alive?(w.channel_pid) end)
       |> Enum.map(fn {{_tid, worker_id}, w} ->
-        %{worker_id: worker_id, capabilities: w.capabilities, tool_count: length(w.tools)}
+        %{worker_id: worker_id, capabilities: w.capabilities, tool_count: length(w.tools), gard: w.gard}
       end)
 
     {:reply, workers, state}

--- a/lib/norns_web/components/layouts/app.html.heex
+++ b/lib/norns_web/components/layouts/app.html.heex
@@ -3,6 +3,7 @@
     <a href="/" class="text-lg font-bold text-gray-900 dark:text-white tracking-tight">norns</a>
     <a href="/" class="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white text-sm">agents</a>
     <a href="/tools" class="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white text-sm">tools</a>
+    <a href="/gards" class="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white text-sm">gards</a>
     <a href="/telemetry" class="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white text-sm">telemetry</a>
     <button onclick="toggleTheme()" class="ml-auto text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
       <span class="dark:hidden">dark</span>

--- a/lib/norns_web/live/gards_live.ex
+++ b/lib/norns_web/live/gards_live.ex
@@ -1,0 +1,118 @@
+defmodule NornsWeb.GardsLive do
+  use NornsWeb, :live_view
+
+  alias Norns.Gards
+  alias Norns.Workers.WorkerRegistry
+
+  @impl true
+  def mount(_params, session, socket) do
+    case load_tenant(session) do
+      {:ok, tenant} ->
+        {:ok, assign(socket, tenant: tenant, current_tenant: tenant) |> load_gards()}
+
+      :error ->
+        {:ok, assign(socket, tenant: nil, current_tenant: nil, gards: [])}
+    end
+  end
+
+  @impl true
+  def handle_event("refresh", _params, socket) do
+    {:noreply, load_gards(socket)}
+  end
+
+  defp load_gards(%{assigns: %{tenant: tenant}} = socket) do
+    workers_by_gard =
+      tenant.id
+      |> WorkerRegistry.connected_workers()
+      |> Enum.filter(& &1.gard)
+      |> Map.new(fn w -> {w.gard, w} end)
+
+    gards =
+      tenant.id
+      |> Gards.list_gards()
+      |> Enum.map(fn gard ->
+        %{
+          gard: gard,
+          ports: Gards.list_ports(gard.id),
+          worker: workers_by_gard[gard.id]
+        }
+      end)
+
+    assign(socket, gards: gards)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <%= if @tenant == nil do %>
+      <div class="mt-20 text-center text-gray-500">
+        <p class="text-lg mb-2">Not authenticated</p>
+        <p class="text-sm">Append <code class="text-gray-600 dark:text-gray-400">?token=your-api-key</code> to the URL</p>
+      </div>
+    <% else %>
+      <div class="flex items-center justify-between mb-6">
+        <h1 class="text-xl font-bold text-gray-900 dark:text-white">Gards</h1>
+        <button phx-click="refresh" class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">refresh</button>
+      </div>
+
+      <%= if @gards == [] do %>
+        <p class="text-xs text-gray-500 dark:text-gray-600">
+          No gards. Create one with <code class="text-gray-600 dark:text-gray-400">nornsctl gards create</code> —
+          a gard pins all of a run's tool dispatch to one worker.
+        </p>
+      <% else %>
+        <div class="space-y-2">
+          <%= for %{gard: gard, ports: ports, worker: worker} <- @gards do %>
+            <div class="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded px-4 py-3">
+              <div class="flex items-center gap-3">
+                <span class={status_class(gard.status)}>●</span>
+                <span class="text-sm text-gray-900 dark:text-white"><%= gard.name || "gard_#{gard.id}" %></span>
+                <span class="text-xs text-gray-500">#<%= gard.id %></span>
+                <span class="text-xs text-gray-500"><%= gard.status %></span>
+                <%= if gard.template do %>
+                  <span class="text-xs text-gray-500">template: <%= gard.template %></span>
+                <% end %>
+                <%= if worker do %>
+                  <span class="text-xs text-blue-700 dark:text-blue-600 ml-auto">
+                    worker: <%= worker.worker_id %> (<%= worker.tool_count %> tools)
+                  </span>
+                <% end %>
+              </div>
+
+              <%= if ports != [] do %>
+                <div class="mt-2 space-y-1">
+                  <%= for port <- ports do %>
+                    <div class="text-xs text-gray-600 dark:text-gray-400 pl-6">
+                      :<%= port.internal_port %>
+                      <%= if port.name && port.name != "" do %>(<%= port.name %>)<% end %>
+                      <%= if port.url do %>
+                        →
+                        <a href={port.url} target="_blank" rel="noopener noreferrer" class="text-blue-700 dark:text-blue-500 hover:underline">
+                          <%= port.url %>
+                        </a>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+    """
+  end
+
+  defp status_class("ready"), do: "text-green-600"
+  defp status_class("pending"), do: "text-yellow-600"
+  defp status_class("disconnected"), do: "text-red-600"
+  defp status_class(_), do: "text-gray-500"
+
+  defp load_tenant(%{"tenant_id" => tenant_id}) do
+    {:ok, Norns.Tenants.get_tenant!(tenant_id)}
+  rescue
+    _ -> :error
+  end
+
+  defp load_tenant(_), do: :error
+end

--- a/lib/norns_web/live/run_live.ex
+++ b/lib/norns_web/live/run_live.ex
@@ -56,7 +56,11 @@ defmodule NornsWeb.RunLive do
     <div class="grid grid-cols-4 gap-4 mb-6">
       <div class="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded p-3">
         <div class="text-xs text-gray-500">Trigger</div>
-        <div class="text-sm"><%= @run.trigger_type %></div>
+        <div class="text-sm">
+          <%= @run.trigger_type %><%= if @run.gard_id do %>
+            <span class="text-xs text-gray-500 ml-2">gard #<%= @run.gard_id %></span>
+          <% end %>
+        </div>
       </div>
       <div class="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded p-3">
         <div class="text-xs text-gray-500">Started</div>

--- a/lib/norns_web/router.ex
+++ b/lib/norns_web/router.ex
@@ -24,6 +24,7 @@ defmodule NornsWeb.Router do
     live "/agents/:id", AgentLive
     live "/runs/:id", RunLive
     live "/tools", ToolsLive
+    live "/gards", GardsLive
     live "/telemetry", TelemetryLive
   end
 

--- a/priv/static/assets/app.css
+++ b/priv/static/assets/app.css
@@ -260,6 +260,9 @@
   .mt-1 {
     margin-top: calc(var(--spacing) * 1);
   }
+  .mt-2 {
+    margin-top: calc(var(--spacing) * 2);
+  }
   .mt-4 {
     margin-top: calc(var(--spacing) * 4);
   }
@@ -544,6 +547,9 @@
   .pt-2 {
     padding-top: calc(var(--spacing) * 2);
   }
+  .pl-6 {
+    padding-left: calc(var(--spacing) * 6);
+  }
   .text-center {
     text-align: center;
   }
@@ -708,6 +714,13 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-red-700);
+      }
+    }
+  }
+  .hover\:underline {
+    &:hover {
+      @media (hover: hover) {
+        text-decoration-line: underline;
       }
     }
   }


### PR DESCRIPTION
Completes the gards Phase 1 surface in this repo (PR #12 shipped the core):

- **`/gards` LiveView** — each gard with a status dot (ready/pending/disconnected/destroyed), its connected worker (`connected_workers` now includes the gard claim), and registered ports rendered as links (URL schemes are validated server-side, so links are safe to render).
- **Run detail** shows the gard a run is bound to, next to the trigger type.
- Nav link added; rebuilt `app.css` included for the new page.

Verified against a live setup: `nornsctl gards create` → Python SDK worker claims → dashboard shows the gard ready with worker and port; kill the worker → status flips to disconnected.

The companion changes shipped separately: `nornsctl gards` (create/list/inspect/ports/destroy) in the nornsctl repo, and `gard`/`claim_token` on `run()` plus `register_port` in the Python SDK.