### PR TITLE
Inbound webhooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ lib/norns/
   runs/             — Run + RunEvent schemas, Runs context (event log)
   runtime/          — Event contracts, error taxonomy, retry policy
   gards/            — Gard + GardPort schemas; Gards context (worker affinity)
+  hooks/            — Hook schema, Signature verification; Hooks context (webhook ingress)
   triggers/         — Trigger schema + context (cron schedules that start runs)
   workers/          — WorkerRegistry, TaskQueue, ResumeAgents, TriggerScheduler
   llm.ex            — LLM dispatcher (used by workers via Fake in tests)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ lib/norns/
   runs/             — Run + RunEvent schemas, Runs context (event log)
   runtime/          — Event contracts, error taxonomy, retry policy
   gards/            — Gard + GardPort schemas; Gards context (worker affinity)
+  hooks/            — Hook schema, Signature verification; Hooks context (webhook ingress)
   triggers/         — Trigger schema + context (cron schedules that start runs)
   workers/          — WorkerRegistry, TaskQueue, ResumeAgents, TriggerScheduler
   llm.ex            — LLM dispatcher (used by workers via Fake in tests)

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -134,6 +134,12 @@ Last updated: 2026-08-10
 - `nornsctl agents message --wait` — the missing loop primitive; terminal-state summary or the parked question with its reply command.
 - Found and fixed en route: litellm 1.96.1 ships cp310-only wheels, breaking every fresh `norns-sdk` install on Python 3.11+ — excluded in the SDK (needs a PyPI release) and constrained in the templates until then.
 
+### Inbound webhooks
+- `POST /api/v1/hooks/:token` — public ingress that starts a run on the mapped agent (`trigger_type: "webhook"`). The server-generated token in the URL is the credential; unknown and disabled tokens answer identically.
+- Provider signatures verified against the **raw body** (cached by a scoped `body_reader` before JSON parsing): `github` (X-Hub-Signature-256), `stripe` (t/v1 with replay bound), `slack` (v0 with replay bound). Constant-time comparison throughout; a signature type requires a secret at write time.
+- `message_path` extracts the run message from the payload (default: the whole payload as pretty JSON); `conversation_key_path` keys persistent history per sender, namespaced `hook_{id}_` so hook-derived keys can't collide with client keys.
+- Busy conversations return 409 — webhook providers retry non-2xx, which is the desired backoff for free.
+
 ### Sub-agent crash recovery
 - A resumed parent reattaches to its in-flight child by run id instead of relaunching it — a pending `launch_agent` is a reference to work already underway, not a request.
 - Subscribe-before-read closes the completion race; `run_id` rides on every agent broadcast; a parent resumed alone restarts its own orphaned child.

--- a/docs/plan-agent-builder.md
+++ b/docs/plan-agent-builder.md
@@ -76,7 +76,7 @@ This also put `trigger_type` to work: runs started by a trigger carry
 `"schedule"`, improving filtering and debugging for free. `"webhook"`
 arrives with inbound webhooks.
 
-### 3. Inbound webhooks (Layer 2 of the trigger surface)
+### 3. Inbound webhooks (Layer 2 of the trigger surface) — shipped 2026-08-13
 
 Many services just POST to a URL (Twilio, Mailgun/SES inbound email, GitHub,
 Stripe). For those, a connector process is pointless glue. One small, pure

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,7 +57,7 @@ flowchart TB
     B["2 — Cron triggers ✓<br/>triggers table · Oban · API — shipped 2026-08-10"]
     C["3 — Gards Phase 1 ✓<br/>registry + dispatch filter — shipped 2026-08-10"]
     D["4 — Fabricate toolkit ✓<br/>templates · scaffold AGENTS.md · --wait — shipped 2026-08-11"]
-    E["5 — Inbound webhooks<br/>POST /api/v1/hooks/:token · signature verification"]
+    E["5 — Inbound webhooks ✓<br/>POST /api/v1/hooks/:token · signatures — shipped 2026-08-13"]
     F["6 — Provisioner<br/>separate repo · managed connectors first, then coding-agent gards"]
     A --> B --> C --> D --> E --> F
 ```
@@ -113,14 +113,17 @@ Still open from the template family: a `slack-connector` variant (Socket
 Mode inbound listener) — the scaffold's `AGENTS.md` documents the pattern;
 build it with the first connector-hosting work.
 
-### 5. Inbound webhooks
+### 5. Inbound webhooks — done (2026-08-13)
 
-`POST /api/v1/hooks/:hook_token` → run on the mapped agent, with optional
-conversation-key extraction from the payload. Pure ingress, per-hook token
-auth — plus provider signature verification (Slack signing secret, Stripe
-signature) designed in from the start. Makes Twilio/Mailgun/GitHub/Stripe
-integration configuration instead of code, shrinking the set of things that
-need a connector at all.
+Shipped: `POST /api/v1/hooks/:token` starts a run on the mapped agent with
+`trigger_type: "webhook"`. Per-hook server-generated tokens; provider
+signature verification (`github`, `stripe`, `slack` — HMAC over the raw
+body, constant-time compare, replay-bounded timestamps); optional
+`message_path` (e.g. Twilio's `Body`) and `conversation_key_path` (e.g.
+`From`, so each sender keeps its own history — verified by test). Unknown
+and disabled tokens are indistinguishable; a busy conversation returns 409
+so providers retry. Management CRUD at `/api/v1/hooks` + `nornsctl hooks`.
+Twilio/Mailgun/GitHub/Stripe are now configuration instead of code.
 
 ### 6. Provisioner (separate repo)
 

--- a/lib/norns/hooks.ex
+++ b/lib/norns/hooks.ex
@@ -1,0 +1,105 @@
+defmodule Norns.Hooks do
+  @moduledoc """
+  Inbound webhooks: token-addressed ingress that starts runs.
+
+  Management is tenant-scoped CRUD; ingest (`handle_delivery/4`) is the
+  public path — look up by token, verify the provider signature against the
+  raw body, extract the message and conversation key, start a run with
+  `trigger_type: "webhook"`.
+  """
+
+  import Ecto.Query
+
+  alias Norns.Repo
+  alias Norns.Hooks.{Hook, Signature}
+  alias Norns.Agents.Registry
+
+  # -- CRUD (tenant-scoped) --
+
+  def list_hooks(tenant_id) do
+    Repo.all(from h in Hook, where: h.tenant_id == ^tenant_id, order_by: h.id)
+  end
+
+  def get_hook(tenant_id, id) do
+    Repo.get_by(Hook, id: id, tenant_id: tenant_id)
+  end
+
+  def create_hook(attrs) do
+    %Hook{}
+    |> Hook.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_hook(%Hook{} = hook, attrs) do
+    hook
+    |> Hook.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def delete_hook(%Hook{} = hook) do
+    Repo.delete(hook)
+  end
+
+  # -- Ingest --
+
+  @doc """
+  Handle a webhook delivery addressed by `token`.
+
+  Returns `{:ok, run_id}`, or `{:error, code}` where code maps to a response:
+  `:not_found` (unknown or disabled token — indistinguishable on purpose),
+  `:busy` (the mapped conversation has a run in flight; the provider should
+  retry), or a signature error string from `Norns.Hooks.Signature`.
+  """
+  def handle_delivery(token, payload, raw_body, headers) when is_binary(token) do
+    case Repo.get_by(Hook, token: token) do
+      %Hook{enabled: true} = hook ->
+        with :ok <- Signature.verify(hook, raw_body, headers) do
+          fire(hook, payload)
+        end
+
+      # Disabled reads the same as unknown — a token that stops working
+      # reveals nothing about whether it ever existed.
+      _ ->
+        {:error, :not_found}
+    end
+  end
+
+  defp fire(hook, payload) do
+    message = extract_message(hook, payload)
+
+    opts = [trigger_type: "webhook"]
+
+    opts =
+      case extract_path(payload, hook.conversation_key_path) do
+        value when is_binary(value) and value != "" ->
+          # Prefix keeps hook-derived keys from colliding with client keys.
+          Keyword.put(opts, :conversation_key, "hook_#{hook.id}_#{value}")
+
+        _ ->
+          opts
+      end
+
+    Registry.send_message(hook.tenant_id, hook.agent_id, message, opts)
+  end
+
+  defp extract_message(hook, payload) do
+    case extract_path(payload, hook.message_path) do
+      value when is_binary(value) and value != "" -> value
+      value when is_number(value) -> to_string(value)
+      _ -> Jason.encode!(payload, pretty: true)
+    end
+  end
+
+  # Dot-path into a (string-keyed) JSON payload: "event.channel" etc.
+  defp extract_path(_payload, nil), do: nil
+  defp extract_path(_payload, ""), do: nil
+
+  defp extract_path(payload, path) when is_map(payload) do
+    get_in(payload, String.split(path, "."))
+  rescue
+    # get_in raises on non-map intermediates (e.g. path into a list/string).
+    _ -> nil
+  end
+
+  defp extract_path(_payload, _path), do: nil
+end

--- a/lib/norns/hooks/hook.ex
+++ b/lib/norns/hooks/hook.ex
@@ -1,0 +1,86 @@
+defmodule Norns.Hooks.Hook do
+  @moduledoc """
+  An inbound webhook: `POST /api/v1/hooks/:token` starts a run on the mapped
+  agent. Pure ingress — this is the messages endpoint with per-hook token
+  auth, so services that speak HTTP (Twilio, Mailgun, GitHub, Stripe) become
+  configuration instead of connector code.
+
+  The token in the URL is the credential; it is server-generated and unique.
+  Optional extras:
+
+    * `message_path` — dot-path into the JSON payload used as the run's
+      message (e.g. `"Body"` for Twilio SMS). Unset, the whole payload is
+      passed as pretty-printed JSON.
+    * `conversation_key_path` — dot-path whose value keys the conversation
+      (e.g. `"From"`, so each phone number keeps its own history). Unset,
+      every delivery starts a fresh conversation.
+    * `signature_type` + `signing_secret` — provider signature verification
+      (`github`, `stripe`, `slack`, or `none`). See `Norns.Hooks.Signature`.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @signature_types ~w(none github stripe slack)
+
+  schema "hooks" do
+    field :name, :string
+    field :token, :string
+    field :message_path, :string
+    field :conversation_key_path, :string
+    field :signature_type, :string, default: "none"
+    field :signing_secret, :string
+    field :enabled, :boolean, default: true
+
+    belongs_to :tenant, Norns.Tenants.Tenant
+    belongs_to :agent, Norns.Agents.Agent
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def signature_types, do: @signature_types
+
+  def changeset(hook, attrs) do
+    hook
+    |> cast(attrs, [
+      :tenant_id,
+      :agent_id,
+      :name,
+      :message_path,
+      :conversation_key_path,
+      :signature_type,
+      :signing_secret,
+      :enabled
+    ])
+    |> validate_required([:tenant_id, :agent_id, :name])
+    |> validate_inclusion(:signature_type, @signature_types)
+    |> validate_secret_present()
+    |> put_token()
+    |> unique_constraint([:tenant_id, :name])
+    |> unique_constraint(:token)
+    |> foreign_key_constraint(:agent_id)
+  end
+
+  defp validate_secret_present(changeset) do
+    type = get_field(changeset, :signature_type)
+    secret = get_field(changeset, :signing_secret)
+
+    if type != "none" and (is_nil(secret) or secret == "") do
+      add_error(changeset, :signing_secret, "is required when signature_type is #{type}")
+    else
+      changeset
+    end
+  end
+
+  # Tokens are always generated server-side — never user-supplied.
+  defp put_token(changeset) do
+    case get_field(changeset, :token) do
+      nil ->
+        token = :crypto.strong_rand_bytes(32) |> Base.url_encode64(padding: false)
+        put_change(changeset, :token, token)
+
+      _ ->
+        changeset
+    end
+  end
+end

--- a/lib/norns/hooks/signature.ex
+++ b/lib/norns/hooks/signature.ex
@@ -1,0 +1,100 @@
+defmodule Norns.Hooks.Signature do
+  @moduledoc """
+  Provider signature verification for inbound webhooks.
+
+  Verification runs against the **raw request body** (cached before JSON
+  parsing — see `NornsWeb.CacheBodyReader`), because every provider signs
+  bytes on the wire, not parsed params. All comparisons are constant-time.
+
+  Supported schemes:
+
+    * `"none"` — token-in-URL only
+    * `"github"` — `X-Hub-Signature-256: sha256=<hmac>` over the body
+    * `"stripe"` — `Stripe-Signature: t=<ts>,v1=<hmac>` over `"{t}.{body}"`
+    * `"slack"` — `X-Slack-Signature: v0=<hmac>` over
+      `"v0:{X-Slack-Request-Timestamp}:{body}"`
+
+  Stripe and Slack signatures include a timestamp; deliveries older than
+  #{5} minutes are rejected to bound replay.
+  """
+
+  @tolerance_seconds 300
+
+  @doc """
+  Verify a delivery. `headers` is a `{name, value}` list with lowercase
+  names (as `conn.req_headers` provides). Returns `:ok` or `{:error, code}`
+  with a stable code: `"missing_signature"`, `"invalid_signature"`, or
+  `"stale_timestamp"`.
+  """
+  def verify(%{signature_type: "none"}, _raw_body, _headers), do: :ok
+
+  def verify(%{signature_type: "github", signing_secret: secret}, raw_body, headers) do
+    with {:ok, header} <- fetch_header(headers, "x-hub-signature-256") do
+      expected = "sha256=" <> hmac_hex(secret, raw_body)
+      compare(header, expected)
+    end
+  end
+
+  def verify(%{signature_type: "stripe", signing_secret: secret}, raw_body, headers) do
+    with {:ok, header} <- fetch_header(headers, "stripe-signature"),
+         %{"t" => timestamp, "v1" => signature} <- parse_kv(header, ","),
+         :ok <- check_timestamp(timestamp) do
+      expected = hmac_hex(secret, "#{timestamp}.#{raw_body}")
+      compare(signature, expected)
+    else
+      {:error, _} = error -> error
+      _ -> {:error, "missing_signature"}
+    end
+  end
+
+  def verify(%{signature_type: "slack", signing_secret: secret}, raw_body, headers) do
+    with {:ok, signature} <- fetch_header(headers, "x-slack-signature"),
+         {:ok, timestamp} <- fetch_header(headers, "x-slack-request-timestamp"),
+         :ok <- check_timestamp(timestamp) do
+      expected = "v0=" <> hmac_hex(secret, "v0:#{timestamp}:#{raw_body}")
+      compare(signature, expected)
+    end
+  end
+
+  defp hmac_hex(secret, data) do
+    :hmac
+    |> :crypto.mac(:sha256, secret, data)
+    |> Base.encode16(case: :lower)
+  end
+
+  defp compare(provided, expected) do
+    if Plug.Crypto.secure_compare(provided, expected) do
+      :ok
+    else
+      {:error, "invalid_signature"}
+    end
+  end
+
+  defp fetch_header(headers, name) do
+    case List.keyfind(headers, name, 0) do
+      {_, value} when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, "missing_signature"}
+    end
+  end
+
+  # "t=123,v1=abc" → %{"t" => "123", "v1" => "abc"}
+  defp parse_kv(header, separator) do
+    header
+    |> String.split(separator)
+    |> Enum.reduce(%{}, fn pair, acc ->
+      case String.split(pair, "=", parts: 2) do
+        [key, value] -> Map.put(acc, String.trim(key), value)
+        _ -> acc
+      end
+    end)
+  end
+
+  defp check_timestamp(timestamp) do
+    with {seconds, ""} <- Integer.parse(timestamp),
+         true <- abs(System.os_time(:second) - seconds) <= @tolerance_seconds do
+      :ok
+    else
+      _ -> {:error, "stale_timestamp"}
+    end
+  end
+end

--- a/lib/norns_web/cache_body_reader.ex
+++ b/lib/norns_web/cache_body_reader.ex
@@ -1,0 +1,28 @@
+defmodule NornsWeb.CacheBodyReader do
+  @moduledoc """
+  Body reader for `Plug.Parsers` that stashes the raw request body on webhook
+  ingest requests before parsing consumes it. Provider signatures (GitHub,
+  Stripe, Slack) are HMACs over the bytes on the wire — parsed params can't
+  reproduce them.
+
+  Only `/api/v1/hooks/:token` deliveries are cached; every other request
+  keeps the default zero-copy behaviour.
+  """
+
+  def read_body(conn, opts) do
+    case Plug.Conn.read_body(conn, opts) do
+      {:ok, body, conn} -> {:ok, body, maybe_cache(conn, body)}
+      {:more, body, conn} -> {:more, body, maybe_cache(conn, body)}
+      other -> other
+    end
+  end
+
+  # Ingest is POST /api/v1/hooks/<token> — exactly four path segments.
+  # Management routes (POST /api/v1/hooks) don't match and aren't cached.
+  defp maybe_cache(%Plug.Conn{path_info: ["api", "v1", "hooks", _token]} = conn, body) do
+    cached = conn.assigns[:raw_body] || []
+    Plug.Conn.assign(conn, :raw_body, cached ++ [body])
+  end
+
+  defp maybe_cache(conn, _body), do: conn
+end

--- a/lib/norns_web/controllers/hook_controller.ex
+++ b/lib/norns_web/controllers/hook_controller.ex
@@ -1,0 +1,84 @@
+defmodule NornsWeb.HookController do
+  use NornsWeb, :controller
+
+  alias Norns.Hooks
+
+  def index(conn, _params) do
+    tenant = conn.assigns.current_tenant
+    json(conn, %{data: Enum.map(Hooks.list_hooks(tenant.id), &NornsWeb.JSON.hook/1)})
+  end
+
+  def create(conn, params) do
+    tenant = conn.assigns.current_tenant
+    attrs = params |> Map.drop(["token"]) |> Map.put("tenant_id", tenant.id)
+
+    case Hooks.create_hook(attrs) do
+      {:ok, hook} ->
+        conn |> put_status(201) |> json(%{data: NornsWeb.JSON.hook(hook)})
+
+      {:error, changeset} ->
+        conn |> put_status(422) |> json(%{error: format_errors(changeset)})
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    tenant = conn.assigns.current_tenant
+
+    with {:ok, hook} <- fetch_hook(tenant.id, id) do
+      json(conn, %{data: NornsWeb.JSON.hook(hook)})
+    end
+  end
+
+  def update(conn, %{"id" => id} = params) do
+    tenant = conn.assigns.current_tenant
+
+    with {:ok, hook} <- fetch_hook(tenant.id, id) do
+      attrs = Map.drop(params, ["id", "tenant_id", "agent_id", "token"])
+
+      case Hooks.update_hook(hook, attrs) do
+        {:ok, hook} ->
+          json(conn, %{data: NornsWeb.JSON.hook(hook)})
+
+        {:error, changeset} ->
+          conn |> put_status(422) |> json(%{error: format_errors(changeset)})
+      end
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    tenant = conn.assigns.current_tenant
+
+    with {:ok, hook} <- fetch_hook(tenant.id, id) do
+      {:ok, _} = Hooks.delete_hook(hook)
+      send_resp(conn, 204, "")
+    end
+  end
+
+  defp fetch_hook(tenant_id, id) do
+    case Hooks.get_hook(tenant_id, id) do
+      nil -> {:error, :not_found}
+      hook -> {:ok, hook}
+    end
+  end
+
+  defp format_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Regex.replace(~r"%{(\w+)}", msg, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
+
+  # Override action/2 to handle {:error, :not_found} from with clauses
+  def action(conn, _) do
+    args = [conn, conn.params]
+
+    case apply(__MODULE__, action_name(conn), args) do
+      {:error, :not_found} ->
+        conn |> put_status(404) |> json(%{error: "not found"})
+
+      conn ->
+        conn
+    end
+  end
+end

--- a/lib/norns_web/controllers/hook_ingest_controller.ex
+++ b/lib/norns_web/controllers/hook_ingest_controller.ex
@@ -1,0 +1,37 @@
+defmodule NornsWeb.HookIngestController do
+  @moduledoc """
+  The public webhook ingress: `POST /api/v1/hooks/:token`.
+
+  The token in the URL is the credential. Status codes are chosen for
+  provider retry semantics: 202 on success, 409 when the mapped conversation
+  is busy (providers retry non-2xx, which is exactly what we want), 401 on a
+  failed signature, 404 for unknown-or-disabled tokens (indistinguishable on
+  purpose).
+  """
+
+  use NornsWeb, :controller
+
+  alias Norns.Hooks
+
+  def create(conn, %{"token" => token}) do
+    payload = Map.drop(conn.body_params, ["token"])
+    raw_body = IO.iodata_to_binary(conn.assigns[:raw_body] || [])
+
+    case Hooks.handle_delivery(token, payload, raw_body, conn.req_headers) do
+      {:ok, run_id} ->
+        conn |> put_status(202) |> json(%{status: "accepted", run_id: run_id})
+
+      {:error, :not_found} ->
+        conn |> put_status(404) |> json(%{error: "not found"})
+
+      {:error, :busy} ->
+        conn |> put_status(409) |> json(%{error: "agent is busy — retry later"})
+
+      {:error, reason} when reason in ["missing_signature", "invalid_signature", "stale_timestamp"] ->
+        conn |> put_status(401) |> json(%{error: reason})
+
+      {:error, reason} ->
+        conn |> put_status(500) |> json(%{error: inspect(reason)})
+    end
+  end
+end

--- a/lib/norns_web/endpoint.ex
+++ b/lib/norns_web/endpoint.ex
@@ -29,7 +29,8 @@ defmodule NornsWeb.Endpoint do
   plug Plug.Parsers,
     parsers: [:urlencoded, :json],
     pass: ["*/*"],
-    json_decoder: Phoenix.json_library()
+    json_decoder: Phoenix.json_library(),
+    body_reader: {NornsWeb.CacheBodyReader, :read_body, []}
 
   plug Plug.Session, @session_options
   plug NornsWeb.Router

--- a/lib/norns_web/json.ex
+++ b/lib/norns_web/json.ex
@@ -62,6 +62,22 @@ defmodule NornsWeb.JSON do
     }
   end
 
+  def hook(hook) do
+    %{
+      id: hook.id,
+      agent_id: hook.agent_id,
+      name: hook.name,
+      token: hook.token,
+      path: "/api/v1/hooks/#{hook.token}",
+      message_path: hook.message_path,
+      conversation_key_path: hook.conversation_key_path,
+      signature_type: hook.signature_type,
+      enabled: hook.enabled,
+      inserted_at: hook.inserted_at,
+      updated_at: hook.updated_at
+    }
+  end
+
   def trigger(trigger) do
     %{
       id: trigger.id,

--- a/lib/norns_web/router.ex
+++ b/lib/norns_web/router.ex
@@ -36,6 +36,10 @@ defmodule NornsWeb.Router do
     pipe_through :api_public
 
     post "/telemetry/first-run", TelemetryController, :first_run
+
+    # Webhook ingress — the token in the path is the credential; provider
+    # signature verification happens in the controller against the raw body.
+    post "/hooks/:token", HookIngestController, :create
   end
 
   scope "/api/v1", NornsWeb do
@@ -59,6 +63,10 @@ defmodule NornsWeb.Router do
     resources "/gards", GardController, only: [:create, :index, :show, :update, :delete] do
       get "/ports", GardController, :ports
     end
+
+    # Hook management. No collision with public ingest: ingest is POST
+    # /hooks/:token, and nothing here answers POST on /hooks/:id.
+    resources "/hooks", HookController, only: [:create, :index, :show, :update, :delete]
 
     get "/runs", RunController, :index
     get "/runs/:id", RunController, :show

--- a/priv/repo/migrations/20260813000100_create_hooks.exs
+++ b/priv/repo/migrations/20260813000100_create_hooks.exs
@@ -1,0 +1,23 @@
+defmodule Norns.Repo.Migrations.CreateHooks do
+  use Ecto.Migration
+
+  def change do
+    create table(:hooks) do
+      add :tenant_id, references(:tenants), null: false
+      add :agent_id, references(:agents), null: false
+      add :name, :string, null: false
+      add :token, :string, null: false
+      add :message_path, :string
+      add :conversation_key_path, :string
+      add :signature_type, :string, null: false, default: "none"
+      add :signing_secret, :string
+      add :enabled, :boolean, default: true, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:hooks, [:token])
+    create unique_index(:hooks, [:tenant_id, :name])
+    create index(:hooks, [:tenant_id])
+  end
+end

--- a/test/norns/hooks/signature_test.exs
+++ b/test/norns/hooks/signature_test.exs
@@ -1,0 +1,88 @@
+defmodule Norns.Hooks.SignatureTest do
+  use ExUnit.Case, async: true
+
+  alias Norns.Hooks.Signature
+
+  @secret "whsec_test_secret"
+  @body ~s({"event":"push"})
+
+  defp hmac(data), do: :hmac |> :crypto.mac(:sha256, @secret, data) |> Base.encode16(case: :lower)
+
+  defp hook(type), do: %{signature_type: type, signing_secret: @secret}
+
+  describe "none" do
+    test "always passes" do
+      assert Signature.verify(hook("none"), @body, []) == :ok
+    end
+  end
+
+  describe "github" do
+    test "accepts a valid X-Hub-Signature-256" do
+      headers = [{"x-hub-signature-256", "sha256=" <> hmac(@body)}]
+      assert Signature.verify(hook("github"), @body, headers) == :ok
+    end
+
+    test "rejects a tampered body" do
+      headers = [{"x-hub-signature-256", "sha256=" <> hmac(@body)}]
+      assert Signature.verify(hook("github"), @body <> "x", headers) == {:error, "invalid_signature"}
+    end
+
+    test "rejects a missing header" do
+      assert Signature.verify(hook("github"), @body, []) == {:error, "missing_signature"}
+    end
+  end
+
+  describe "stripe" do
+    test "accepts a valid Stripe-Signature" do
+      timestamp = System.os_time(:second)
+      headers = [{"stripe-signature", "t=#{timestamp},v1=#{hmac("#{timestamp}.#{@body}")}"}]
+      assert Signature.verify(hook("stripe"), @body, headers) == :ok
+    end
+
+    test "rejects a stale timestamp" do
+      timestamp = System.os_time(:second) - 600
+      headers = [{"stripe-signature", "t=#{timestamp},v1=#{hmac("#{timestamp}.#{@body}")}"}]
+      assert Signature.verify(hook("stripe"), @body, headers) == {:error, "stale_timestamp"}
+    end
+
+    test "rejects a wrong signature" do
+      timestamp = System.os_time(:second)
+      headers = [{"stripe-signature", "t=#{timestamp},v1=#{hmac("wrong")}"}]
+      assert Signature.verify(hook("stripe"), @body, headers) == {:error, "invalid_signature"}
+    end
+
+    test "rejects a malformed header" do
+      assert Signature.verify(hook("stripe"), @body, [{"stripe-signature", "garbage"}]) ==
+               {:error, "missing_signature"}
+    end
+  end
+
+  describe "slack" do
+    test "accepts a valid v0 signature" do
+      timestamp = to_string(System.os_time(:second))
+
+      headers = [
+        {"x-slack-signature", "v0=" <> hmac("v0:#{timestamp}:#{@body}")},
+        {"x-slack-request-timestamp", timestamp}
+      ]
+
+      assert Signature.verify(hook("slack"), @body, headers) == :ok
+    end
+
+    test "rejects a replayed timestamp" do
+      timestamp = to_string(System.os_time(:second) - 600)
+
+      headers = [
+        {"x-slack-signature", "v0=" <> hmac("v0:#{timestamp}:#{@body}")},
+        {"x-slack-request-timestamp", timestamp}
+      ]
+
+      assert Signature.verify(hook("slack"), @body, headers) == {:error, "stale_timestamp"}
+    end
+
+    test "rejects a missing timestamp header" do
+      headers = [{"x-slack-signature", "v0=" <> hmac("anything")}]
+      assert Signature.verify(hook("slack"), @body, headers) == {:error, "missing_signature"}
+    end
+  end
+end

--- a/test/norns_web/controllers/hook_controller_test.exs
+++ b/test/norns_web/controllers/hook_controller_test.exs
@@ -1,0 +1,199 @@
+defmodule NornsWeb.HookControllerTest do
+  use NornsWeb.ConnCase, async: false
+
+  alias Norns.{Hooks, Runs}
+  alias Norns.LLM.Fake
+
+  setup %{conn: conn} do
+    tenant = create_tenant()
+    agent = create_agent(tenant)
+    conn = authenticated_conn(conn, tenant)
+    %{conn: conn, tenant: tenant, agent: agent}
+  end
+
+  defp create_hook(conn, agent, attrs \\ %{}) do
+    params =
+      Map.merge(
+        %{"agent_id" => agent.id, "name" => "hook-#{System.unique_integer([:positive])}"},
+        attrs
+      )
+
+    json_response(post(conn, "/api/v1/hooks", params), 201)["data"]
+  end
+
+  defp await_completion(_agent_id) do
+    receive do
+      {:completed, _} -> :ok
+      {:error, _} -> :ok
+    after
+      5000 -> flunk("run did not finish")
+    end
+  end
+
+  describe "management CRUD" do
+    test "creates a hook with a server-generated token", %{conn: conn, agent: agent} do
+      data = create_hook(conn, agent)
+
+      assert String.length(data["token"]) == 43
+      assert data["path"] == "/api/v1/hooks/#{data["token"]}"
+      assert data["signature_type"] == "none"
+      assert data["enabled"] == true
+    end
+
+    test "a signature type requires a secret", %{conn: conn, agent: agent} do
+      conn =
+        post(conn, "/api/v1/hooks", %{
+          "agent_id" => agent.id,
+          "name" => "gh",
+          "signature_type" => "github"
+        })
+
+      assert %{"error" => %{"signing_secret" => _}} = json_response(conn, 422)
+    end
+
+    test "a client-supplied token is ignored", %{conn: conn, agent: agent} do
+      data = create_hook(conn, agent, %{"token" => "attacker-chosen"})
+      refute data["token"] == "attacker-chosen"
+    end
+
+    test "list and show are tenant-scoped", %{conn: conn, agent: agent} do
+      created = create_hook(conn, agent)
+
+      other = create_tenant()
+      other_agent = create_agent(other)
+      {:ok, theirs} = Hooks.create_hook(%{tenant_id: other.id, agent_id: other_agent.id, name: "theirs"})
+
+      assert %{"data" => [%{"id" => id}]} = json_response(get(conn, "/api/v1/hooks"), 200)
+      assert id == created["id"]
+      assert json_response(get(conn, "/api/v1/hooks/#{theirs.id}"), 404)
+    end
+
+    test "update can disable; delete removes", %{conn: conn, agent: agent} do
+      %{"id" => id} = create_hook(conn, agent)
+
+      assert %{"data" => %{"enabled" => false}} =
+               json_response(patch(conn, "/api/v1/hooks/#{id}", %{"enabled" => false}), 200)
+
+      assert response(delete(conn, "/api/v1/hooks/#{id}"), 204)
+      assert json_response(get(conn, "/api/v1/hooks/#{id}"), 404)
+    end
+  end
+
+  describe "ingest" do
+    test "a delivery starts a webhook-triggered run; payload is the message", %{conn: conn, agent: agent} do
+      %{"token" => token} = create_hook(conn, agent)
+
+      Fake.set_responses([
+        %{content: [%{"type" => "text", "text" => "handled"}], stop_reason: "end_turn"}
+      ])
+
+      Phoenix.PubSub.subscribe(Norns.PubSub, "agent:#{agent.id}")
+
+      # No auth header — ingest is public, the token is the credential.
+      conn =
+        Phoenix.ConnTest.build_conn()
+        |> post("/api/v1/hooks/#{token}", %{"event" => "invoice.paid", "amount" => 42})
+
+      assert %{"status" => "accepted", "run_id" => run_id} = json_response(conn, 202)
+      await_completion(agent.id)
+
+      run = Runs.get_run!(run_id)
+      assert run.trigger_type == "webhook"
+      assert run.input["user_message"] =~ "invoice.paid"
+      assert run.input["user_message"] =~ "42"
+    end
+
+    test "message_path extracts a field; conversation_key_path keys history", %{conn: conn, agent: agent} do
+      %{"token" => token} =
+        create_hook(conn, agent, %{
+          "message_path" => "Body",
+          "conversation_key_path" => "From"
+        })
+
+      Fake.set_responses([
+        %{content: [%{"type" => "text", "text" => "one"}], stop_reason: "end_turn"},
+        %{content: [%{"type" => "text", "text" => "two"}], stop_reason: "end_turn"}
+      ])
+
+      Phoenix.PubSub.subscribe(Norns.PubSub, "agent:#{agent.id}")
+
+      post(Phoenix.ConnTest.build_conn(), "/api/v1/hooks/#{token}", %{
+        "From" => "+15551234567",
+        "Body" => "first text"
+      })
+
+      await_completion(agent.id)
+
+      post(Phoenix.ConnTest.build_conn(), "/api/v1/hooks/#{token}", %{
+        "From" => "+15551234567",
+        "Body" => "second text"
+      })
+
+      await_completion(agent.id)
+
+      # Same sender → same conversation → the second call sees history.
+      [first, second] = Fake.calls()
+      assert length(first.messages) == 1
+      assert length(second.messages) == 3
+      assert %{"content" => "first text"} = hd(first.messages)
+    end
+
+    test "unknown and disabled tokens read identically", %{conn: conn, agent: agent} do
+      %{"id" => id, "token" => token} = create_hook(conn, agent)
+      patch(conn, "/api/v1/hooks/#{id}", %{"enabled" => false})
+
+      unknown = post(Phoenix.ConnTest.build_conn(), "/api/v1/hooks/nope", %{"a" => 1})
+      disabled = post(Phoenix.ConnTest.build_conn(), "/api/v1/hooks/#{token}", %{"a" => 1})
+
+      assert json_response(unknown, 404) == json_response(disabled, 404)
+    end
+
+    test "a signed hook rejects bad and missing signatures, accepts valid ones", %{conn: conn, agent: agent} do
+      secret = "gh_secret"
+
+      %{"token" => token} =
+        create_hook(conn, agent, %{"signature_type" => "github", "signing_secret" => secret})
+
+      body = Jason.encode!(%{"action" => "opened"})
+
+      unsigned =
+        Phoenix.ConnTest.build_conn()
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v1/hooks/#{token}", body)
+
+      assert json_response(unsigned, 401)["error"] == "missing_signature"
+
+      forged =
+        Phoenix.ConnTest.build_conn()
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("x-hub-signature-256", "sha256=" <> String.duplicate("0", 64))
+        |> post("/api/v1/hooks/#{token}", body)
+
+      assert json_response(forged, 401)["error"] == "invalid_signature"
+
+      Fake.set_responses([
+        %{content: [%{"type" => "text", "text" => "ok"}], stop_reason: "end_turn"}
+      ])
+
+      Phoenix.PubSub.subscribe(Norns.PubSub, "agent:#{agent.id}")
+
+      mac = :hmac |> :crypto.mac(:sha256, secret, body) |> Base.encode16(case: :lower)
+
+      signed =
+        Phoenix.ConnTest.build_conn()
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("x-hub-signature-256", "sha256=" <> mac)
+        |> post("/api/v1/hooks/#{token}", body)
+
+      assert %{"run_id" => _} = json_response(signed, 202)
+      await_completion(agent.id)
+    end
+
+    test "ingest does not require tenant auth but management does", %{agent: agent, conn: conn} do
+      %{"token" => _token} = create_hook(conn, agent)
+
+      unauthed = get(Phoenix.ConnTest.build_conn(), "/api/v1/hooks")
+      assert unauthed.status in [401, 403]
+    end
+  end
+end


### PR DESCRIPTION
Roadmap step 5, the last core primitive before the provisioner. `POST /api/v1/hooks/:token` starts a run on the mapped agent — pure ingress with per-hook token auth, so services that speak HTTP (Twilio, Mailgun, GitHub, Stripe) become configuration instead of connector code.

## What

- **`hooks` table + `Norns.Hooks`** — agent mapping, server-generated 43-char tokens (client-supplied tokens ignored on create), optional `message_path` (e.g. Twilio's `Body`; default is the whole payload as pretty JSON) and `conversation_key_path` (e.g. `From` — each sender keeps its own history, namespaced `hook_{id}_` so it can't collide with client keys), `enabled` flag.
- **Provider signature verification** (`Norns.Hooks.Signature`): `github` (X-Hub-Signature-256), `stripe` (`t`/`v1`, 5-minute replay bound), `slack` (v0, replay bound), or `none`. Verified against the **raw request body** via a `body_reader` scoped to the ingest path — providers sign wire bytes, parsed params can't reproduce them. Constant-time comparisons; a signature type requires a secret at write time.
- **Response semantics tuned for providers**: 202 accepted, 401 on signature failure, 409 when the mapped conversation is busy (providers retry non-2xx — free backoff), 404 for unknown *and* disabled tokens, deliberately indistinguishable.
- **Runs record `trigger_type: "webhook"`**; management CRUD at `/api/v1/hooks` behind normal tenant auth, ingest on the public pipeline.

## Tests

21 new: signature vectors for all three schemes (valid, tampered body, forged, stale timestamp, missing headers), CRUD + tenant scoping + secret requirement + token-override rejection, and full ingest integration — payload-as-message, `message_path`/`conversation_key_path` with verified cross-delivery history, unknown≡disabled, unsigned/forged/valid GitHub deliveries, and public-ingest-vs-authed-management. Full suite: 291 tests, 0 failures, warnings-as-errors and credo clean.

`nornsctl hooks` commands follow in the nornsctl repo.