### PR TITLE
Add GET /api/v1/workers

### DIFF
--- a/lib/norns_web/controllers/worker_controller.ex
+++ b/lib/norns_web/controllers/worker_controller.ex
@@ -1,0 +1,18 @@
+defmodule NornsWeb.WorkerController do
+  use NornsWeb, :controller
+
+  alias Norns.Workers.WorkerRegistry
+
+  @doc """
+  Workers currently holding a connection for this tenant.
+
+  The liveness half of the deployment picture: an operator (or provisioner)
+  can see that a container is running, but only this endpoint says whether
+  the worker inside it reached Norns and registered. A deployment that is
+  "running" in Docker and absent here is crash-looping or can't connect.
+  """
+  def index(conn, _params) do
+    tenant = conn.assigns.current_tenant
+    json(conn, %{data: WorkerRegistry.connected_workers(tenant.id)})
+  end
+end

--- a/lib/norns_web/router.ex
+++ b/lib/norns_web/router.ex
@@ -55,6 +55,7 @@ defmodule NornsWeb.Router do
     end
 
     get "/tools", ToolController, :index
+    get "/workers", WorkerController, :index
 
     resources "/triggers", TriggerController, only: [:create, :index, :show, :update, :delete] do
       post "/fire", TriggerController, :fire

--- a/test/norns_web/controllers/worker_controller_test.exs
+++ b/test/norns_web/controllers/worker_controller_test.exs
@@ -1,0 +1,68 @@
+defmodule NornsWeb.WorkerControllerTest do
+  use NornsWeb.ConnCase, async: false
+
+  alias Norns.Workers.WorkerRegistry
+
+  setup %{conn: conn} do
+    tenant = create_tenant()
+    %{conn: authenticated_conn(conn, tenant), tenant: tenant}
+  end
+
+  defp register_worker(tenant, worker_id, opts \\ []) do
+    WorkerRegistry.register_worker(
+      tenant.id,
+      worker_id,
+      self(),
+      Keyword.get(opts, :tools, []),
+      capabilities: Keyword.get(opts, :capabilities, [:tools]),
+      gard: Keyword.get(opts, :gard)
+    )
+
+    on_exit(fn -> WorkerRegistry.unregister_worker(tenant.id, worker_id) end)
+  end
+
+  defp tool_def(name) do
+    %{"name" => name, "description" => "does #{name}", "input_schema" => %{"type" => "object"}}
+  end
+
+  describe "GET /api/v1/workers" do
+    test "empty when no worker is connected", %{conn: conn} do
+      assert %{"data" => []} = json_response(get(conn, "/api/v1/workers"), 200)
+    end
+
+    test "lists a connected worker with capabilities, tool count, and gard", %{
+      conn: conn,
+      tenant: tenant
+    } do
+      register_worker(tenant, "slack-connector",
+        tools: [tool_def("post_to_slack"), tool_def("list_slack_channels")],
+        capabilities: [:llm, :tools]
+      )
+
+      assert %{"data" => [worker]} = json_response(get(conn, "/api/v1/workers"), 200)
+      assert worker["worker_id"] == "slack-connector"
+      assert Enum.sort(worker["capabilities"]) == ["llm", "tools"]
+      assert worker["tool_count"] == 2
+      assert worker["gard"] == nil
+    end
+
+    test "includes the gard for a gard-bound worker", %{conn: conn, tenant: tenant} do
+      register_worker(tenant, "coding-worker", gard: "gard_abc")
+
+      assert %{"data" => [worker]} = json_response(get(conn, "/api/v1/workers"), 200)
+      assert worker["gard"] == "gard_abc"
+    end
+
+    test "does not list another tenant's workers", %{conn: conn} do
+      other = create_tenant()
+      register_worker(other, "other-worker")
+
+      assert %{"data" => []} = json_response(get(conn, "/api/v1/workers"), 200)
+    end
+
+    test "requires authentication" do
+      conn = get(Phoenix.ConnTest.build_conn(), "/api/v1/workers")
+      assert conn.status in [401, 403]
+    end
+  end
+end


### PR DESCRIPTION
Exposes `WorkerRegistry.connected_workers/1` over REST — `worker_id`, `capabilities`, `tool_count`, and `gard` for each worker currently holding a connection, tenant-scoped.

This is the liveness half of the deployment picture: a container can be running while the worker inside it never reaches Norns. Joining container state with this endpoint distinguishes healthy from crash-looping — the query the provisioner's `list` command is built on (docs/roadmap.md § 6).

## Changes
- `NornsWeb.WorkerController` — `index/2` returning `connected_workers/1` as `{"data": [...]}`
- Router: `GET /workers` in the authed `/api/v1` scope
- Tests: empty list, fields for a connected worker, gard-bound worker, tenant isolation, auth required

296 tests, 0 failures.